### PR TITLE
Simplify memory.x and add build.rs for linking memory.x

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/memory.x
+++ b/memory.x
@@ -4,8 +4,3 @@ MEMORY
   FLASH : ORIGIN = 0x00000000, LENGTH = 256K
   RAM : ORIGIN = 0x20000000, LENGTH = 16K
 }
-
-/* This is where the call stack will be allocated. */
-/* The stack is of the full descending type. */
-/* NOTE Do NOT modify `_stack_start` unless you know what you are doing */
-_stack_start = ORIGIN(RAM) + LENGTH(RAM);


### PR DESCRIPTION
The section removed from memory.x is now the default.

build.rs will allow users of this crate to not need to include memory.x themselves.