### PR TITLE
Add a nonblocking LED display driver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cortex-m = "0.5.8"
 cortex-m-rt = "0.6.7"
 nb = "0.1.1"
 nrf51-hal = "0.6.0"
+tiny-led-matrix = "0.1"
 
 [dev-dependencies]
 cortex-m-semihosting = "0.3.2"

--- a/examples/led_nonblocking.rs
+++ b/examples/led_nonblocking.rs
@@ -9,9 +9,9 @@ use cortex_m::interrupt::Mutex;
 use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
-use microbit::hal::nrf51::{interrupt, GPIO, RTC0, TIMER1};
-use microbit::display::{self, Display, Frame, MicrobitFrame};
 use microbit::display::image::GreyscaleImage;
+use microbit::display::{self, Display, Frame, MicrobitFrame};
+use microbit::hal::nrf51::{interrupt, GPIO, RTC0, TIMER1};
 
 fn heart_image(inner_brightness: u8) -> GreyscaleImage {
     let b = inner_brightness;
@@ -30,20 +30,18 @@ fn heart_image(inner_brightness: u8) -> GreyscaleImage {
 static GPIO: Mutex<RefCell<Option<GPIO>>> = Mutex::new(RefCell::new(None));
 static RTC0: Mutex<RefCell<Option<RTC0>>> = Mutex::new(RefCell::new(None));
 static TIMER1: Mutex<RefCell<Option<TIMER1>>> = Mutex::new(RefCell::new(None));
-static DISPLAY: Mutex<RefCell<Option<Display<MicrobitFrame>>>> =
-    Mutex::new(RefCell::new(None));
+static DISPLAY: Mutex<RefCell<Option<Display<MicrobitFrame>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
     if let Some(mut p) = microbit::Peripherals::take() {
-
         // Starting the low-frequency clock (needed for RTC to work)
         p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
         while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
         p.CLOCK.events_lfclkstarted.write(|w| unsafe { w.bits(0) });
 
         // 16Hz; 62.5ms period
-        p.RTC0.prescaler.write(|w| unsafe {w.bits(2047)});
+        p.RTC0.prescaler.write(|w| unsafe { w.bits(2047) });
         p.RTC0.evtenset.write(|w| w.tick().set_bit());
         p.RTC0.intenset.write(|w| w.tick().set_bit());
         p.RTC0.tasks_start.write(|w| unsafe { w.bits(1) });
@@ -57,7 +55,6 @@ fn main() -> ! {
             *DISPLAY.borrow(cs).borrow_mut() = Some(Display::new());
         });
 
-
         if let Some(mut cp) = Peripherals::take() {
             unsafe {
                 cp.NVIC.set_priority(microbit::Interrupt::RTC0, 64);
@@ -68,9 +65,7 @@ fn main() -> ! {
             microbit::NVIC::unpend(microbit::Interrupt::RTC0);
             microbit::NVIC::unpend(microbit::Interrupt::TIMER1);
         }
-
     }
-
 
     loop {
         continue;
@@ -97,14 +92,14 @@ fn RTC0() {
 
     cortex_m::interrupt::free(|cs| {
         if let Some(rtc0) = RTC0.borrow(cs).borrow().as_ref() {
-            rtc0.events_tick.write(|w| unsafe {w.bits(0)} );
+            rtc0.events_tick.write(|w| unsafe { w.bits(0) });
         }
     });
 
     let inner_brightness = match *STEP {
-        0..=8 => 9-*STEP,
+        0..=8 => 9 - *STEP,
         9..=12 => 0,
-        _ => unreachable!()
+        _ => unreachable!(),
     };
 
     FRAME.set(&mut heart_image(inner_brightness));
@@ -116,7 +111,7 @@ fn RTC0() {
     });
 
     *STEP += 1;
-    if *STEP == 13 {*STEP = 0};
-
+    if *STEP == 13 {
+        *STEP = 0
+    };
 }
-

--- a/examples/led_nonblocking.rs
+++ b/examples/led_nonblocking.rs
@@ -1,0 +1,122 @@
+#![no_main]
+#![no_std]
+
+#[allow(unused)]
+use panic_halt;
+
+use core::cell::RefCell;
+use cortex_m::interrupt::Mutex;
+use cortex_m::peripheral::Peripherals;
+use cortex_m_rt::entry;
+
+use microbit::hal::nrf51::{interrupt, GPIO, RTC0, TIMER1};
+use microbit::display::{self, Display, Frame, MicrobitFrame};
+use microbit::display::image::GreyscaleImage;
+
+fn heart_image(inner_brightness: u8) -> GreyscaleImage {
+    let b = inner_brightness;
+    GreyscaleImage::new(&[
+        [0, 7, 0, 7, 0],
+        [7, b, 7, b, 7],
+        [7, b, b, b, 7],
+        [0, 7, b, 7, 0],
+        [0, 0, 7, 0, 0],
+    ])
+}
+
+// We use TIMER1 to drive the display, and RTC0 to update the animation.
+// We set the TIMER1 interrupt to a higher priority than RTC0.
+
+static GPIO: Mutex<RefCell<Option<GPIO>>> = Mutex::new(RefCell::new(None));
+static RTC0: Mutex<RefCell<Option<RTC0>>> = Mutex::new(RefCell::new(None));
+static TIMER1: Mutex<RefCell<Option<TIMER1>>> = Mutex::new(RefCell::new(None));
+static DISPLAY: Mutex<RefCell<Option<Display<MicrobitFrame>>>> =
+    Mutex::new(RefCell::new(None));
+
+#[entry]
+fn main() -> ! {
+    if let Some(mut p) = microbit::Peripherals::take() {
+
+        // Starting the low-frequency clock (needed for RTC to work)
+        p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
+        while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
+        p.CLOCK.events_lfclkstarted.write(|w| unsafe { w.bits(0) });
+
+        // 16Hz; 62.5ms period
+        p.RTC0.prescaler.write(|w| unsafe {w.bits(2047)});
+        p.RTC0.evtenset.write(|w| w.tick().set_bit());
+        p.RTC0.intenset.write(|w| w.tick().set_bit());
+        p.RTC0.tasks_start.write(|w| unsafe { w.bits(1) });
+
+        display::initialise_display(&mut p.TIMER1, &mut p.GPIO);
+
+        cortex_m::interrupt::free(move |cs| {
+            *GPIO.borrow(cs).borrow_mut() = Some(p.GPIO);
+            *RTC0.borrow(cs).borrow_mut() = Some(p.RTC0);
+            *TIMER1.borrow(cs).borrow_mut() = Some(p.TIMER1);
+            *DISPLAY.borrow(cs).borrow_mut() = Some(Display::new());
+        });
+
+
+        if let Some(mut cp) = Peripherals::take() {
+            unsafe {
+                cp.NVIC.set_priority(microbit::Interrupt::RTC0, 64);
+                cp.NVIC.set_priority(microbit::Interrupt::TIMER1, 128);
+            }
+            cp.NVIC.enable(microbit::Interrupt::RTC0);
+            cp.NVIC.enable(microbit::Interrupt::TIMER1);
+            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+            microbit::NVIC::unpend(microbit::Interrupt::TIMER1);
+        }
+
+    }
+
+
+    loop {
+        continue;
+    }
+}
+
+#[interrupt]
+fn TIMER1() {
+    cortex_m::interrupt::free(|cs| {
+        if let Some(timer1) = TIMER1.borrow(cs).borrow_mut().as_mut() {
+            if let Some(gpio) = GPIO.borrow(cs).borrow_mut().as_mut() {
+                if let Some(d) = DISPLAY.borrow(cs).borrow_mut().as_mut() {
+                    display::handle_display_event(d, timer1, gpio);
+                }
+            }
+        }
+    });
+}
+
+#[interrupt]
+fn RTC0() {
+    static mut STEP: u8 = 0;
+    static mut FRAME: MicrobitFrame = MicrobitFrame::const_default();
+
+    cortex_m::interrupt::free(|cs| {
+        if let Some(rtc0) = RTC0.borrow(cs).borrow().as_ref() {
+            rtc0.events_tick.write(|w| unsafe {w.bits(0)} );
+        }
+    });
+
+    let inner_brightness = match *STEP {
+        0..=8 => 9-*STEP,
+        9..=12 => 0,
+        _ => unreachable!()
+    };
+
+    FRAME.set(&mut heart_image(inner_brightness));
+
+    cortex_m::interrupt::free(|cs| {
+        if let Some(d) = DISPLAY.borrow(cs).borrow_mut().as_mut() {
+            d.set_frame(&FRAME);
+        }
+    });
+
+    *STEP += 1;
+    if *STEP == 13 {*STEP = 0};
+
+}
+

--- a/src/display/doc_example.rs
+++ b/src/display/doc_example.rs
@@ -15,10 +15,10 @@
 //! #[allow(unused)]
 //! use panic_halt;
 //!
-//! use rtfm::app;
-//! use microbit::hal::nrf51;
-//! use microbit::display::{self, Display, Frame, MicrobitFrame};
 //! use microbit::display::image::GreyscaleImage;
+//! use microbit::display::{self, Display, Frame, MicrobitFrame};
+//! use microbit::hal::nrf51;
+//! use rtfm::app;
 //!
 //! fn heart_image(inner_brightness: u8) -> GreyscaleImage {
 //!     let b = inner_brightness;
@@ -33,7 +33,6 @@
 //!
 //! #[app(device = microbit::hal::nrf51)]
 //! const APP: () = {
-//!
 //!     static mut GPIO: nrf51::GPIO = ();
 //!     static mut TIMER1: nrf51::TIMER1 = ();
 //!     static mut RTC0: nrf51::RTC0 = ();
@@ -49,7 +48,7 @@
 //!         p.CLOCK.events_lfclkstarted.write(|w| unsafe { w.bits(0) });
 //!
 //!         // 16Hz; 62.5ms period
-//!         p.RTC0.prescaler.write(|w| unsafe {w.bits(2047)});
+//!         p.RTC0.prescaler.write(|w| unsafe { w.bits(2047) });
 //!         p.RTC0.evtenset.write(|w| w.tick().set_bit());
 //!         p.RTC0.intenset.write(|w| w.tick().set_bit());
 //!         p.RTC0.tasks_start.write(|w| unsafe { w.bits(1) });
@@ -57,21 +56,17 @@
 //!         display::initialise_display(&mut p.TIMER1, &mut p.GPIO);
 //!
 //!         init::LateResources {
-//!             GPIO : p.GPIO,
-//!             TIMER1 : p.TIMER1,
-//!             RTC0 : p.RTC0,
-//!             DISPLAY : Display::new(),
+//!             GPIO: p.GPIO,
+//!             TIMER1: p.TIMER1,
+//!             RTC0: p.RTC0,
+//!             DISPLAY: Display::new(),
 //!         }
 //!     }
 //!
 //!     #[interrupt(priority = 2,
 //!                 resources = [TIMER1, GPIO, DISPLAY])]
 //!     fn TIMER1() {
-//!         display::handle_display_event(
-//!             &mut resources.DISPLAY,
-//!             resources.TIMER1,
-//!             resources.GPIO,
-//!         );
+//!         display::handle_display_event(&mut resources.DISPLAY, resources.TIMER1, resources.GPIO);
 //!     }
 //!
 //!     #[interrupt(priority = 1,
@@ -81,12 +76,12 @@
 //!         static mut STEP: u8 = 0;
 //!
 //!         let event_reg = &resources.RTC0.events_tick;
-//!         event_reg.write(|w| unsafe {w.bits(0)} );
+//!         event_reg.write(|w| unsafe { w.bits(0) });
 //!
 //!         let inner_brightness = match *STEP {
-//!             0..=8 => 9-*STEP,
+//!             0..=8 => 9 - *STEP,
 //!             9..=12 => 0,
-//!             _ => unreachable!()
+//!             _ => unreachable!(),
 //!         };
 //!
 //!         FRAME.set(&mut heart_image(inner_brightness));
@@ -95,8 +90,9 @@
 //!         });
 //!
 //!         *STEP += 1;
-//!         if *STEP == 13 {*STEP = 0};
+//!         if *STEP == 13 {
+//!             *STEP = 0
+//!         };
 //!     }
-//!
 //! };
 //! ```

--- a/src/display/doc_example.rs
+++ b/src/display/doc_example.rs
@@ -1,0 +1,102 @@
+//! A complete working example.
+//!
+//! This requires `cortex-m-rtfm` v0.4.1.
+//!
+//! It uses `TIMER1` to drive the display, and `RTC0` to update a simple
+//! animated image.
+//!
+//! A version of this code which doesn't use `cortex-m-rtfm` is as
+//! `examples/led_nonblocking.rs`.
+//!
+//! ```
+//! #![no_main]
+//! #![no_std]
+//!
+//! #[allow(unused)]
+//! use panic_halt;
+//!
+//! use rtfm::app;
+//! use microbit::hal::nrf51;
+//! use microbit::display::{self, Display, Frame, MicrobitFrame};
+//! use microbit::display::image::GreyscaleImage;
+//!
+//! fn heart_image(inner_brightness: u8) -> GreyscaleImage {
+//!     let b = inner_brightness;
+//!     GreyscaleImage::new(&[
+//!         [0, 7, 0, 7, 0],
+//!         [7, b, 7, b, 7],
+//!         [7, b, b, b, 7],
+//!         [0, 7, b, 7, 0],
+//!         [0, 0, 7, 0, 0],
+//!     ])
+//! }
+//!
+//! #[app(device = microbit::hal::nrf51)]
+//! const APP: () = {
+//!
+//!     static mut GPIO: nrf51::GPIO = ();
+//!     static mut TIMER1: nrf51::TIMER1 = ();
+//!     static mut RTC0: nrf51::RTC0 = ();
+//!     static mut DISPLAY: Display<MicrobitFrame> = ();
+//!
+//!     #[init]
+//!     fn init() -> init::LateResources {
+//!         let mut p: nrf51::Peripherals = device;
+//!
+//!         // Starting the low-frequency clock (needed for RTC to work)
+//!         p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
+//!         while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
+//!         p.CLOCK.events_lfclkstarted.write(|w| unsafe { w.bits(0) });
+//!
+//!         // 16Hz; 62.5ms period
+//!         p.RTC0.prescaler.write(|w| unsafe {w.bits(2047)});
+//!         p.RTC0.evtenset.write(|w| w.tick().set_bit());
+//!         p.RTC0.intenset.write(|w| w.tick().set_bit());
+//!         p.RTC0.tasks_start.write(|w| unsafe { w.bits(1) });
+//!
+//!         display::initialise_display(&mut p.TIMER1, &mut p.GPIO);
+//!
+//!         init::LateResources {
+//!             GPIO : p.GPIO,
+//!             TIMER1 : p.TIMER1,
+//!             RTC0 : p.RTC0,
+//!             DISPLAY : Display::new(),
+//!         }
+//!     }
+//!
+//!     #[interrupt(priority = 2,
+//!                 resources = [TIMER1, GPIO, DISPLAY])]
+//!     fn TIMER1() {
+//!         display::handle_display_event(
+//!             &mut resources.DISPLAY,
+//!             resources.TIMER1,
+//!             resources.GPIO,
+//!         );
+//!     }
+//!
+//!     #[interrupt(priority = 1,
+//!                 resources = [RTC0, DISPLAY])]
+//!     fn RTC0() {
+//!         static mut FRAME: MicrobitFrame = MicrobitFrame::const_default();
+//!         static mut STEP: u8 = 0;
+//!
+//!         let event_reg = &resources.RTC0.events_tick;
+//!         event_reg.write(|w| unsafe {w.bits(0)} );
+//!
+//!         let inner_brightness = match *STEP {
+//!             0..=8 => 9-*STEP,
+//!             9..=12 => 0,
+//!             _ => unreachable!()
+//!         };
+//!
+//!         FRAME.set(&mut heart_image(inner_brightness));
+//!         resources.DISPLAY.lock(|display| {
+//!             display.set_frame(FRAME);
+//!         });
+//!
+//!         *STEP += 1;
+//!         if *STEP == 13 {*STEP = 0};
+//!     }
+//!
+//! };
+//! ```

--- a/src/display/image.rs
+++ b/src/display/image.rs
@@ -1,0 +1,120 @@
+//! Static 5×5 greyscale and black-and-white images.
+
+use tiny_led_matrix::{Render, MAX_BRIGHTNESS};
+
+/// A 5×5 image supporting the full range of brightnesses for each LED.
+///
+/// Uses 25 bytes of storage.
+#[derive(Copy, Clone, Debug)]
+pub struct GreyscaleImage (
+    [[u8; 5]; 5]
+);
+
+
+impl GreyscaleImage {
+
+    /// Constructs a GreyscaleImage from an array of brightnesses.
+    ///
+    /// The data should be an array of 5 rows (top first), each of which is an
+    /// array of 5 brightness values (left first).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// const GREY_HEART: GreyscaleImage = GreyscaleImage::new(&[
+    ///     [0, 9, 0, 9, 0],
+    ///     [9, 5, 9, 5, 9],
+    ///     [9, 5, 5, 5, 9],
+    ///     [0, 9, 5, 9, 0],
+    ///     [0, 0, 9, 0, 0],
+    /// ]);
+    /// ```
+    pub const fn new(data: &[[u8; 5]; 5]) -> GreyscaleImage {
+        GreyscaleImage(*data)
+    }
+
+    pub const fn blank() -> GreyscaleImage {
+        GreyscaleImage([[0; 5]; 5])
+    }
+
+}
+
+impl Render for GreyscaleImage {
+
+    fn brightness_at(&self, x: usize, y: usize) -> u8 {
+        self.0[y][x]
+    }
+}
+
+impl Render for &GreyscaleImage {
+    fn brightness_at(&self, x: usize, y: usize) -> u8 {
+        GreyscaleImage::brightness_at(self, x, y)
+    }
+}
+
+
+/// A 5×5 image supporting only two levels of brightness (on and off).
+///
+/// Uses 5 bytes of storage.
+///
+/// For display, each pixel is treated as having brightness either 0 or
+/// MAX_BRIGHTNESS.
+#[derive(Copy, Clone, Debug)]
+pub struct BitImage (
+    [u8; 5]
+);
+
+impl BitImage {
+
+    /// Constructs a BitImage from an array of brightnesses.
+    ///
+    /// The data should be an array of 5 rows (top first), each of which is an
+    /// array of 5 values (left first). Each value should be either 0 or 1.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// const HEART: BitImage = BitImage::new(&[
+    ///     [0, 1, 0, 1, 0],
+    ///     [1, 0, 1, 0, 1],
+    ///     [1, 0, 0, 0, 1],
+    ///     [0, 1, 0, 1, 0],
+    ///     [0, 0, 1, 0, 0],
+    /// ]);
+    /// ```
+    pub const fn new(im: &[[u8; 5]; 5]) -> BitImage {
+        // FIXME: can we reject values other than 0 or 1?
+        const fn row_byte(row: [u8; 5]) -> u8 {
+            row[0] | row[1]<<1 | row[2]<<2 | row[3]<<3 | row[4]<<4
+        };
+        BitImage([
+            row_byte(im[0]),
+            row_byte(im[1]),
+            row_byte(im[2]),
+            row_byte(im[3]),
+            row_byte(im[4]),
+        ])
+    }
+
+    /// Returns a new blank BitImage.
+    ///
+    /// All pixel values are 0.
+    pub const fn blank() -> BitImage {
+        BitImage([0; 5])
+    }
+
+}
+
+impl Render for BitImage {
+    fn brightness_at(&self, x: usize, y: usize) -> u8 {
+        let rowdata = self.0[y];
+        if rowdata & (1<<x) != 0 {MAX_BRIGHTNESS as u8} else {0}
+    }
+}
+
+impl Render for &BitImage {
+    fn brightness_at(&self, x: usize, y: usize) -> u8 {
+        BitImage::brightness_at(self, x, y)
+    }
+}
+

--- a/src/display/image.rs
+++ b/src/display/image.rs
@@ -6,13 +6,9 @@ use tiny_led_matrix::{Render, MAX_BRIGHTNESS};
 ///
 /// Uses 25 bytes of storage.
 #[derive(Copy, Clone, Debug)]
-pub struct GreyscaleImage (
-    [[u8; 5]; 5]
-);
-
+pub struct GreyscaleImage([[u8; 5]; 5]);
 
 impl GreyscaleImage {
-
     /// Constructs a GreyscaleImage from an array of brightnesses.
     ///
     /// The data should be an array of 5 rows (top first), each of which is an
@@ -36,11 +32,9 @@ impl GreyscaleImage {
     pub const fn blank() -> GreyscaleImage {
         GreyscaleImage([[0; 5]; 5])
     }
-
 }
 
 impl Render for GreyscaleImage {
-
     fn brightness_at(&self, x: usize, y: usize) -> u8 {
         self.0[y][x]
     }
@@ -52,7 +46,6 @@ impl Render for &GreyscaleImage {
     }
 }
 
-
 /// A 5×5 image supporting only two levels of brightness (on and off).
 ///
 /// Uses 5 bytes of storage.
@@ -60,12 +53,9 @@ impl Render for &GreyscaleImage {
 /// For display, each pixel is treated as having brightness either 0 or
 /// MAX_BRIGHTNESS.
 #[derive(Copy, Clone, Debug)]
-pub struct BitImage (
-    [u8; 5]
-);
+pub struct BitImage([u8; 5]);
 
 impl BitImage {
-
     /// Constructs a BitImage from an array of brightnesses.
     ///
     /// The data should be an array of 5 rows (top first), each of which is an
@@ -85,7 +75,7 @@ impl BitImage {
     pub const fn new(im: &[[u8; 5]; 5]) -> BitImage {
         // FIXME: can we reject values other than 0 or 1?
         const fn row_byte(row: [u8; 5]) -> u8 {
-            row[0] | row[1]<<1 | row[2]<<2 | row[3]<<3 | row[4]<<4
+            row[0] | row[1] << 1 | row[2] << 2 | row[3] << 3 | row[4] << 4
         };
         BitImage([
             row_byte(im[0]),
@@ -102,13 +92,16 @@ impl BitImage {
     pub const fn blank() -> BitImage {
         BitImage([0; 5])
     }
-
 }
 
 impl Render for BitImage {
     fn brightness_at(&self, x: usize, y: usize) -> u8 {
         let rowdata = self.0[y];
-        if rowdata & (1<<x) != 0 {MAX_BRIGHTNESS as u8} else {0}
+        if rowdata & (1 << x) != 0 {
+            MAX_BRIGHTNESS as u8
+        } else {
+            0
+        }
     }
 }
 
@@ -117,4 +110,3 @@ impl Render for &BitImage {
         BitImage::brightness_at(self, x, y)
     }
 }
-

--- a/src/display/microbit_control.rs
+++ b/src/display/microbit_control.rs
@@ -1,0 +1,83 @@
+//! Implementation of [`DisplayControl`] for the micro:bit's GPIO peripheral.
+//!
+//! This controls the micro:bit's 5×5 LED display.
+//!
+//! [`DisplayControl`]: tiny_led_matrix::DisplayControl
+
+use crate::hal::nrf51;
+use tiny_led_matrix::DisplayControl;
+
+const fn bit_range(lo: usize, count: usize) -> u32 {
+    return ((1<<count) - 1) << lo
+}
+
+pub(crate) const MATRIX_COLS : usize = 9;
+const FIRST_COL_PIN : usize = 4;
+const LAST_COL_PIN : usize = FIRST_COL_PIN + MATRIX_COLS - 1;
+const COL_BITS : u32 = bit_range(FIRST_COL_PIN, MATRIX_COLS);
+
+pub(crate) const MATRIX_ROWS : usize = 3;
+const FIRST_ROW_PIN : usize = 13;
+const LAST_ROW_PIN : usize = FIRST_ROW_PIN + MATRIX_ROWS - 1;
+const ROW_BITS : u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
+
+
+/// Wrapper for `nrf51::GPIO` for passing to the display code.
+///
+/// This implements the `DisplayControl` trait.
+///
+/// [`DisplayControl`]: tiny_led_matrix::DisplayControl
+pub struct MicrobitGpio<'a> (pub &'a nrf51::GPIO);
+
+/// Returns the GPIO pin numbers corresponding to the columns in a ColumnSet.
+fn column_pins(cols: u32) -> u32 {
+    cols << FIRST_COL_PIN
+}
+
+/// Implementation of [`DisplayControl`] for the micro:bit's GPIO peripheral.
+///
+/// This controls the micro:bit's 5×5 LED display.
+///
+/// The `initialise_for display` implementation assumes the port is in the
+/// state it would have after system reset.
+///
+/// [`DisplayControl`]: tiny_led_matrix::DisplayControl
+impl DisplayControl for MicrobitGpio <'_> {
+
+    fn initialise_for_display(&mut self) {
+        let gpio = &self.0;
+        for ii in FIRST_COL_PIN ..= LAST_COL_PIN {
+            gpio.pin_cnf[ii].write(|w| w.dir().output());
+        }
+        for ii in FIRST_ROW_PIN ..= LAST_ROW_PIN {
+            gpio.pin_cnf[ii].write(|w| w.dir().output());
+        }
+
+        // Set all cols high.
+        gpio.outset.write(|w| unsafe { w.bits(
+            (FIRST_COL_PIN ..= LAST_COL_PIN).map(|pin| 1<<pin).sum()
+        )});
+    }
+
+
+    fn display_row_leds(&mut self, row: usize, cols: u32) {
+        let gpio = &self.0;
+        // To light an LED, we set the row bit and clear the col bit.
+        let rows_to_set = 1<<(FIRST_ROW_PIN+row);
+        let rows_to_clear = ROW_BITS ^ rows_to_set;
+        let cols_to_clear = column_pins(cols);
+        let cols_to_set = COL_BITS ^ cols_to_clear;
+
+        gpio.outset.write(|w| unsafe { w.bits(rows_to_set | cols_to_set) });
+        gpio.outclr.write(|w| unsafe { w.bits(rows_to_clear | cols_to_clear) });
+    }
+
+    fn light_current_row_leds(&mut self, cols: u32) {
+        let gpio = &self.0;
+        gpio.outclr.write(|w| unsafe {
+            w.bits(column_pins(cols))
+        });
+    }
+
+}
+

--- a/src/display/microbit_control.rs
+++ b/src/display/microbit_control.rs
@@ -8,26 +8,25 @@ use crate::hal::nrf51;
 use tiny_led_matrix::DisplayControl;
 
 const fn bit_range(lo: usize, count: usize) -> u32 {
-    return ((1<<count) - 1) << lo
+    return ((1 << count) - 1) << lo;
 }
 
-pub(crate) const MATRIX_COLS : usize = 9;
-const FIRST_COL_PIN : usize = 4;
-const LAST_COL_PIN : usize = FIRST_COL_PIN + MATRIX_COLS - 1;
-const COL_BITS : u32 = bit_range(FIRST_COL_PIN, MATRIX_COLS);
+pub(crate) const MATRIX_COLS: usize = 9;
+const FIRST_COL_PIN: usize = 4;
+const LAST_COL_PIN: usize = FIRST_COL_PIN + MATRIX_COLS - 1;
+const COL_BITS: u32 = bit_range(FIRST_COL_PIN, MATRIX_COLS);
 
-pub(crate) const MATRIX_ROWS : usize = 3;
-const FIRST_ROW_PIN : usize = 13;
-const LAST_ROW_PIN : usize = FIRST_ROW_PIN + MATRIX_ROWS - 1;
-const ROW_BITS : u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
-
+pub(crate) const MATRIX_ROWS: usize = 3;
+const FIRST_ROW_PIN: usize = 13;
+const LAST_ROW_PIN: usize = FIRST_ROW_PIN + MATRIX_ROWS - 1;
+const ROW_BITS: u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
 
 /// Wrapper for `nrf51::GPIO` for passing to the display code.
 ///
 /// This implements the `DisplayControl` trait.
 ///
 /// [`DisplayControl`]: tiny_led_matrix::DisplayControl
-pub struct MicrobitGpio<'a> (pub &'a nrf51::GPIO);
+pub struct MicrobitGpio<'a>(pub &'a nrf51::GPIO);
 
 /// Returns the GPIO pin numbers corresponding to the columns in a ColumnSet.
 fn column_pins(cols: u32) -> u32 {
@@ -42,42 +41,37 @@ fn column_pins(cols: u32) -> u32 {
 /// state it would have after system reset.
 ///
 /// [`DisplayControl`]: tiny_led_matrix::DisplayControl
-impl DisplayControl for MicrobitGpio <'_> {
-
+impl DisplayControl for MicrobitGpio<'_> {
     fn initialise_for_display(&mut self) {
         let gpio = &self.0;
-        for ii in FIRST_COL_PIN ..= LAST_COL_PIN {
+        for ii in FIRST_COL_PIN..=LAST_COL_PIN {
             gpio.pin_cnf[ii].write(|w| w.dir().output());
         }
-        for ii in FIRST_ROW_PIN ..= LAST_ROW_PIN {
+        for ii in FIRST_ROW_PIN..=LAST_ROW_PIN {
             gpio.pin_cnf[ii].write(|w| w.dir().output());
         }
 
         // Set all cols high.
-        gpio.outset.write(|w| unsafe { w.bits(
-            (FIRST_COL_PIN ..= LAST_COL_PIN).map(|pin| 1<<pin).sum()
-        )});
+        gpio.outset
+            .write(|w| unsafe { w.bits((FIRST_COL_PIN..=LAST_COL_PIN).map(|pin| 1 << pin).sum()) });
     }
-
 
     fn display_row_leds(&mut self, row: usize, cols: u32) {
         let gpio = &self.0;
         // To light an LED, we set the row bit and clear the col bit.
-        let rows_to_set = 1<<(FIRST_ROW_PIN+row);
+        let rows_to_set = 1 << (FIRST_ROW_PIN + row);
         let rows_to_clear = ROW_BITS ^ rows_to_set;
         let cols_to_clear = column_pins(cols);
         let cols_to_set = COL_BITS ^ cols_to_clear;
 
-        gpio.outset.write(|w| unsafe { w.bits(rows_to_set | cols_to_set) });
-        gpio.outclr.write(|w| unsafe { w.bits(rows_to_clear | cols_to_clear) });
+        gpio.outset
+            .write(|w| unsafe { w.bits(rows_to_set | cols_to_set) });
+        gpio.outclr
+            .write(|w| unsafe { w.bits(rows_to_clear | cols_to_clear) });
     }
 
     fn light_current_row_leds(&mut self, cols: u32) {
         let gpio = &self.0;
-        gpio.outclr.write(|w| unsafe {
-            w.bits(column_pins(cols))
-        });
+        gpio.outclr.write(|w| unsafe { w.bits(column_pins(cols)) });
     }
-
 }
-

--- a/src/display/microbit_matrix.rs
+++ b/src/display/microbit_matrix.rs
@@ -1,0 +1,94 @@
+//! Implementation of [`Matrix`] and [`Frame`] for the micro:bit's LED display.
+//!
+//! This module describes the correspondence between the visible layout of
+//! micro:bit's LEDs and the pins controlling them.
+//!
+//! [`Matrix`]: tiny_led_matrix::Matrix
+//! [`Frame`]: tiny_led_matrix::Frame
+
+use tiny_led_matrix::{Frame, Matrix, RowPlan};
+use crate::display::microbit_control::{{MATRIX_COLS, MATRIX_ROWS}};
+
+/// Implementation of [`Matrix`] for the microbit's LED display.
+///
+/// [`Matrix`]: tiny_led_matrix::Matrix
+pub struct MicrobitMatrix ();
+
+/// Gives the LED (x, y) coordinates for a given pin row and column.
+/// The origin is in the top-left.
+const MICROBIT_LED_LAYOUT: [[Option<(usize, usize)>; 3]; 9] = [
+    [Some((0, 0)), Some((4, 2)), Some((2, 4))],
+    [Some((2, 0)), Some((0, 2)), Some((4, 4))],
+    [Some((4, 0)), Some((2, 2)), Some((0, 4))],
+    [Some((4, 3)), Some((1, 0)), Some((0, 1))],
+    [Some((3, 3)), Some((3, 0)), Some((1, 1))],
+    [Some((2, 3)), Some((3, 4)), Some((2, 1))],
+    [Some((1, 3)), Some((1, 4)), Some((3, 1))],
+    [Some((0, 3)), None,         Some((4, 1))],
+    [Some((1, 2)), None,         Some((3, 2))],
+];
+
+impl Matrix for MicrobitMatrix {
+
+    /// The number of pins connected to LED columns (3).
+    const MATRIX_COLS: usize = MATRIX_COLS;
+    /// The number of pins connected to LED rows (9).
+    const MATRIX_ROWS: usize = MATRIX_ROWS;
+    /// The number of visible LED columns (5).
+    const IMAGE_COLS: usize = 5;
+    /// The number of visible LED rows (5).
+    const IMAGE_ROWS: usize = 5;
+
+    fn image_coordinates(col: usize, row: usize) -> Option<(usize, usize)> {
+        MICROBIT_LED_LAYOUT[col][row]
+    }
+
+}
+
+
+
+/// A 'Compiled' representation of a 5×5 image to be displayed.
+///
+/// Use the [`.set()`](`Frame::set`) method to store an image (something
+/// implementing [`Render`]) in the frame.
+///
+/// Note you'll have to `use microbit::display::Frame` to make `set()`
+/// available.
+///
+/// [`Frame`]: tiny_led_matrix::Frame
+/// [`Render`]: tiny_led_matrix::Render
+#[derive(Copy, Clone, Debug)]
+pub struct MicrobitFrame (
+    [RowPlan; MicrobitFrame::ROWS]
+);
+
+impl MicrobitFrame {
+    /// Returns a new frame, initially blank.
+    pub const fn const_default() -> MicrobitFrame {
+        MicrobitFrame([RowPlan::default(); MicrobitFrame::ROWS])
+    }
+}
+
+impl Default for MicrobitFrame {
+
+    /// Returns a new frame, initially blank.
+    fn default() -> MicrobitFrame {
+        MicrobitFrame::const_default()
+    }
+
+}
+
+impl Frame for MicrobitFrame {
+
+    type Mtx = MicrobitMatrix;
+
+    fn row_plan(&self, row: usize) -> &RowPlan {
+        &self.0[row]
+    }
+
+    fn row_plan_mut(&mut self, row: usize) -> &mut RowPlan {
+        &mut self.0[row]
+    }
+
+}
+

--- a/src/display/microbit_matrix.rs
+++ b/src/display/microbit_matrix.rs
@@ -6,13 +6,13 @@
 //! [`Matrix`]: tiny_led_matrix::Matrix
 //! [`Frame`]: tiny_led_matrix::Frame
 
+use crate::display::microbit_control::{MATRIX_COLS, MATRIX_ROWS};
 use tiny_led_matrix::{Frame, Matrix, RowPlan};
-use crate::display::microbit_control::{{MATRIX_COLS, MATRIX_ROWS}};
 
 /// Implementation of [`Matrix`] for the microbit's LED display.
 ///
 /// [`Matrix`]: tiny_led_matrix::Matrix
-pub struct MicrobitMatrix ();
+pub struct MicrobitMatrix();
 
 /// Gives the LED (x, y) coordinates for a given pin row and column.
 /// The origin is in the top-left.
@@ -24,12 +24,11 @@ const MICROBIT_LED_LAYOUT: [[Option<(usize, usize)>; 3]; 9] = [
     [Some((3, 3)), Some((3, 0)), Some((1, 1))],
     [Some((2, 3)), Some((3, 4)), Some((2, 1))],
     [Some((1, 3)), Some((1, 4)), Some((3, 1))],
-    [Some((0, 3)), None,         Some((4, 1))],
-    [Some((1, 2)), None,         Some((3, 2))],
+    [Some((0, 3)), None, Some((4, 1))],
+    [Some((1, 2)), None, Some((3, 2))],
 ];
 
 impl Matrix for MicrobitMatrix {
-
     /// The number of pins connected to LED columns (3).
     const MATRIX_COLS: usize = MATRIX_COLS;
     /// The number of pins connected to LED rows (9).
@@ -42,10 +41,7 @@ impl Matrix for MicrobitMatrix {
     fn image_coordinates(col: usize, row: usize) -> Option<(usize, usize)> {
         MICROBIT_LED_LAYOUT[col][row]
     }
-
 }
-
-
 
 /// A 'Compiled' representation of a 5×5 image to be displayed.
 ///
@@ -58,9 +54,7 @@ impl Matrix for MicrobitMatrix {
 /// [`Frame`]: tiny_led_matrix::Frame
 /// [`Render`]: tiny_led_matrix::Render
 #[derive(Copy, Clone, Debug)]
-pub struct MicrobitFrame (
-    [RowPlan; MicrobitFrame::ROWS]
-);
+pub struct MicrobitFrame([RowPlan; MicrobitFrame::ROWS]);
 
 impl MicrobitFrame {
     /// Returns a new frame, initially blank.
@@ -70,16 +64,13 @@ impl MicrobitFrame {
 }
 
 impl Default for MicrobitFrame {
-
     /// Returns a new frame, initially blank.
     fn default() -> MicrobitFrame {
         MicrobitFrame::const_default()
     }
-
 }
 
 impl Frame for MicrobitFrame {
-
     type Mtx = MicrobitMatrix;
 
     fn row_plan(&self, row: usize) -> &RowPlan {
@@ -89,6 +80,4 @@ impl Frame for MicrobitFrame {
     fn row_plan_mut(&mut self, row: usize) -> &mut RowPlan {
         &mut self.0[row]
     }
-
 }
-

--- a/src/display/microbit_timer.rs
+++ b/src/display/microbit_timer.rs
@@ -10,15 +10,16 @@ use tiny_led_matrix::DisplayTimer;
 /// This implements the [`DisplayTimer`] trait.
 ///
 /// [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
-pub(crate) struct MicrobitTimer <'a> (pub &'a nrf51::timer0::RegisterBlock);
-
+pub(crate) struct MicrobitTimer<'a>(pub &'a nrf51::timer0::RegisterBlock);
 
 /// Checks whether the event for a CC register has been generated,
 /// then clears the event register.
 fn check_cc(timer: &nrf51::timer0::RegisterBlock, index: usize) -> bool {
     let event_reg = &timer.events_compare[index];
     let fired = event_reg.read().bits() != 0;
-    if fired {event_reg.write(|w| unsafe {w.bits(0)} )}
+    if fired {
+        event_reg.write(|w| unsafe { w.bits(0) })
+    }
     fired
 }
 
@@ -34,8 +35,7 @@ fn check_cc(timer: &nrf51::timer0::RegisterBlock, index: usize) -> bool {
 ///
 /// check_primary() and check_secondary() take care of clearing the timer's
 /// event registers.
-impl DisplayTimer for MicrobitTimer <'_> {
-
+impl DisplayTimer for MicrobitTimer<'_> {
     fn initialise_cycle(&mut self, ticks: u16) {
         let timer = &self.0;
         timer.prescaler.write(|w| unsafe { w.bits(8) });
@@ -65,6 +65,4 @@ impl DisplayTimer for MicrobitTimer <'_> {
     fn check_secondary(&mut self) -> bool {
         check_cc(&self.0, 1)
     }
-
 }
-

--- a/src/display/microbit_timer.rs
+++ b/src/display/microbit_timer.rs
@@ -2,103 +2,69 @@
 //!
 //! [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
 
+use crate::hal::nrf51;
 use tiny_led_matrix::DisplayTimer;
 
-/// One of the three nrf51 TIMER peripherals.
-pub trait Nrf51Timer<'a> {
-    type Wrapper: DisplayTimer;
+/// Wrapper for an nrf51 `TIMER` for passing to the display code.
+///
+/// This implements the [`DisplayTimer`] trait.
+///
+/// [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
+pub(crate) struct MicrobitTimer <'a> (pub &'a nrf51::timer0::RegisterBlock);
 
-    /// Returns a wrapper for the peripheral, implementing DisplayTimer.
-    fn as_display_timer(&'a mut self) -> Self::Wrapper;
+
+/// Checks whether the event for a CC register has been generated,
+/// then clears the event register.
+fn check_cc(timer: &nrf51::timer0::RegisterBlock, index: usize) -> bool {
+    let event_reg = &timer.events_compare[index];
+    let fired = event_reg.read().bits() != 0;
+    if fired {event_reg.write(|w| unsafe {w.bits(0)} )}
+    fired
 }
 
-// Implements Nrf51Timer for TIMER0, TIMER1, or TIMER2.
-//
-// The timer is set to 16-bit mode, using a 62.5kHz clock (16 µs ticks).
-//
-// Uses CC0 for the primary cycle and CC1 for the secondary alarm. Uses the
-// CC0_CLEAR shortcut to implement the primary cycle.
-//
-// The initialise_cycle() implementation assumes the timer is in the state it
-// would have after system reset.
-//
-// check_primary() and check_secondary() take care of clearing the timer's
-// event registers.
-macro_rules! nrf51_timer {
-    ( $timer:ident, $stimer:expr ) => {
-        #[allow(non_snake_case)]
-        pub mod $timer {
-            use crate::hal::nrf51;
-            use tiny_led_matrix::DisplayTimer;
-            use crate::display::microbit_timer::Nrf51Timer;
-            #[doc = "Wrapper for `"]
-            #[doc = $stimer]
-            #[doc = "` for passing to the display code."]
-            ///
-            /// This implements the [`DisplayTimer`] trait.
-            ///
-            /// [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
-            pub struct MicrobitTimer <'a> (pub &'a mut nrf51::$timer);
+/// Implementation of DisplayTimer for one of the nrf51 `TIMER` peripherals.
+///
+/// The timer is set to 16-bit mode, using a 62.5kHz clock (16 µs ticks).
+///
+/// Uses CC0 for the primary cycle and CC1 for the secondary alarm. Uses the
+/// CC0_CLEAR shortcut to implement the primary cycle.
+///
+/// The initialise_cycle() implementation assumes the timer is in the state it
+/// would have after system reset.
+///
+/// check_primary() and check_secondary() take care of clearing the timer's
+/// event registers.
+impl DisplayTimer for MicrobitTimer <'_> {
 
-            // Checks whether the event for a CC register has been generated,
-            // then clears the event register.
-            fn check_cc(timer: &mut nrf51::$timer, index: usize) -> bool {
-                let event_reg = &timer.events_compare[index];
-                let fired = event_reg.read().bits() != 0;
-                if fired {event_reg.write(|w| unsafe {w.bits(0)} )}
-                return fired;
-            }
-
-            impl DisplayTimer for MicrobitTimer <'_> {
-
-                fn initialise_cycle(&mut self, ticks: u16) {
-                    let timer = &self.0;
-                    timer.prescaler.write(|w| unsafe { w.bits(8) });
-                    timer.cc[0].write(|w| unsafe { w.bits(ticks as u32) });
-                    timer.bitmode.write(|w| w.bitmode()._32bit());
-                    timer.shorts.write(|w| w.compare0_clear().enabled());
-                    timer.intenset.write(|w| w.compare0().set());
-                    timer.tasks_start.write(|w| unsafe { w.bits(1) });
-                }
-
-                fn enable_secondary(&mut self) {
-                    self.0.intenset.write(|w| w.compare1().set());
-                }
-
-                fn disable_secondary(&mut self) {
-                    self.0.intenclr.write(|w| w.compare1().clear());
-                }
-
-                fn program_secondary(&mut self, ticks: u16) {
-                    self.0.cc[1].write(|w| unsafe { w.bits(ticks as u32) });
-                }
-
-                fn check_primary(&mut self) -> bool {
-                    return check_cc(&mut self.0, 0);
-                }
-
-                fn check_secondary(&mut self) -> bool {
-                    return check_cc(&mut self.0, 1);
-                }
-
-            }
-
-            impl<'a> Nrf51Timer<'a> for nrf51::$timer {
-                type Wrapper = MicrobitTimer<'a>;
-
-                fn as_display_timer(&mut self) -> MicrobitTimer {
-                    MicrobitTimer(self)
-                }
-            }
-        }
-
-    };
-    ( $timer:ident ) => {
-        nrf51_timer!($timer, stringify!($timer));
+    fn initialise_cycle(&mut self, ticks: u16) {
+        let timer = &self.0;
+        timer.prescaler.write(|w| unsafe { w.bits(8) });
+        timer.cc[0].write(|w| unsafe { w.bits(ticks as u32) });
+        timer.bitmode.write(|w| w.bitmode()._32bit());
+        timer.shorts.write(|w| w.compare0_clear().enabled());
+        timer.intenset.write(|w| w.compare0().set());
+        timer.tasks_start.write(|w| unsafe { w.bits(1) });
     }
+
+    fn enable_secondary(&mut self) {
+        self.0.intenset.write(|w| w.compare1().set());
+    }
+
+    fn disable_secondary(&mut self) {
+        self.0.intenclr.write(|w| w.compare1().clear());
+    }
+
+    fn program_secondary(&mut self, ticks: u16) {
+        self.0.cc[1].write(|w| unsafe { w.bits(ticks as u32) });
+    }
+
+    fn check_primary(&mut self) -> bool {
+        check_cc(&self.0, 0)
+    }
+
+    fn check_secondary(&mut self) -> bool {
+        check_cc(&self.0, 1)
+    }
+
 }
 
-
-nrf51_timer!(TIMER0);
-nrf51_timer!(TIMER1);
-nrf51_timer!(TIMER2);

--- a/src/display/microbit_timer.rs
+++ b/src/display/microbit_timer.rs
@@ -1,0 +1,104 @@
+//! Implementation of [`DisplayTimer`] for the nrf51 `TIMER`s.
+//!
+//! [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
+
+use tiny_led_matrix::DisplayTimer;
+
+/// One of the three nrf51 TIMER peripherals.
+pub trait Nrf51Timer<'a> {
+    type Wrapper: DisplayTimer;
+
+    /// Returns a wrapper for the peripheral, implementing DisplayTimer.
+    fn as_display_timer(&'a mut self) -> Self::Wrapper;
+}
+
+// Implements Nrf51Timer for TIMER0, TIMER1, or TIMER2.
+//
+// The timer is set to 16-bit mode, using a 62.5kHz clock (16 µs ticks).
+//
+// Uses CC0 for the primary cycle and CC1 for the secondary alarm. Uses the
+// CC0_CLEAR shortcut to implement the primary cycle.
+//
+// The initialise_cycle() implementation assumes the timer is in the state it
+// would have after system reset.
+//
+// check_primary() and check_secondary() take care of clearing the timer's
+// event registers.
+macro_rules! nrf51_timer {
+    ( $timer:ident, $stimer:expr ) => {
+        #[allow(non_snake_case)]
+        pub mod $timer {
+            use crate::hal::nrf51;
+            use tiny_led_matrix::DisplayTimer;
+            use crate::display::microbit_timer::Nrf51Timer;
+            #[doc = "Wrapper for `"]
+            #[doc = $stimer]
+            #[doc = "` for passing to the display code."]
+            ///
+            /// This implements the [`DisplayTimer`] trait.
+            ///
+            /// [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
+            pub struct MicrobitTimer <'a> (pub &'a mut nrf51::$timer);
+
+            // Checks whether the event for a CC register has been generated,
+            // then clears the event register.
+            fn check_cc(timer: &mut nrf51::$timer, index: usize) -> bool {
+                let event_reg = &timer.events_compare[index];
+                let fired = event_reg.read().bits() != 0;
+                if fired {event_reg.write(|w| unsafe {w.bits(0)} )}
+                return fired;
+            }
+
+            impl DisplayTimer for MicrobitTimer <'_> {
+
+                fn initialise_cycle(&mut self, ticks: u16) {
+                    let timer = &self.0;
+                    timer.prescaler.write(|w| unsafe { w.bits(8) });
+                    timer.cc[0].write(|w| unsafe { w.bits(ticks as u32) });
+                    timer.bitmode.write(|w| w.bitmode()._32bit());
+                    timer.shorts.write(|w| w.compare0_clear().enabled());
+                    timer.intenset.write(|w| w.compare0().set());
+                    timer.tasks_start.write(|w| unsafe { w.bits(1) });
+                }
+
+                fn enable_secondary(&mut self) {
+                    self.0.intenset.write(|w| w.compare1().set());
+                }
+
+                fn disable_secondary(&mut self) {
+                    self.0.intenclr.write(|w| w.compare1().clear());
+                }
+
+                fn program_secondary(&mut self, ticks: u16) {
+                    self.0.cc[1].write(|w| unsafe { w.bits(ticks as u32) });
+                }
+
+                fn check_primary(&mut self) -> bool {
+                    return check_cc(&mut self.0, 0);
+                }
+
+                fn check_secondary(&mut self) -> bool {
+                    return check_cc(&mut self.0, 1);
+                }
+
+            }
+
+            impl<'a> Nrf51Timer<'a> for nrf51::$timer {
+                type Wrapper = MicrobitTimer<'a>;
+
+                fn as_display_timer(&mut self) -> MicrobitTimer {
+                    MicrobitTimer(self)
+                }
+            }
+        }
+
+    };
+    ( $timer:ident ) => {
+        nrf51_timer!($timer, stringify!($timer));
+    }
+}
+
+
+nrf51_timer!(TIMER0);
+nrf51_timer!(TIMER1);
+nrf51_timer!(TIMER2);

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -139,12 +139,7 @@
 //!
 
 #[doc(no_inline)]
-pub use tiny_led_matrix::{
-    Render,
-    MAX_BRIGHTNESS,
-    Display,
-    Frame,
-};
+pub use tiny_led_matrix::{Display, Frame, Render, MAX_BRIGHTNESS};
 
 mod microbit_control;
 mod microbit_matrix;
@@ -156,9 +151,8 @@ pub use microbit_matrix::MicrobitFrame;
 
 pub mod doc_example;
 
-
-use core::ops::Deref;
 use crate::hal::nrf51;
+use core::ops::Deref;
 use microbit_control::MicrobitGpio;
 use microbit_timer::MicrobitTimer;
 
@@ -176,10 +170,10 @@ use microbit_timer::MicrobitTimer;
 /// let mut p: nrf51::Peripherals = _;
 /// microbit::display::initialise_display(&mut p.TIMER1, &mut p.GPIO);
 /// ```
-pub fn initialise_display<'a, T>(
-    timer: &'a mut T,
-    gpio: &mut crate::hal::nrf51::GPIO)
-    where T: Deref <Target = nrf51::timer0::RegisterBlock> {
+pub fn initialise_display<'a, T>(timer: &'a mut T, gpio: &mut crate::hal::nrf51::GPIO)
+where
+    T: Deref<Target = nrf51::timer0::RegisterBlock>,
+{
     tiny_led_matrix::initialise_control(&mut MicrobitGpio(gpio));
     tiny_led_matrix::initialise_timer(&mut MicrobitTimer(timer));
 }
@@ -213,11 +207,9 @@ pub fn initialise_display<'a, T>(
 pub fn handle_display_event<'a, T>(
     display: &mut Display<MicrobitFrame>,
     timer: &'a mut T,
-    gpio: &mut crate::hal::nrf51::GPIO)
-    where T: Deref <Target = nrf51::timer0::RegisterBlock> {
-    display.handle_event(
-        &mut MicrobitTimer(timer),
-        &mut MicrobitGpio(gpio),
-    );
+    gpio: &mut crate::hal::nrf51::GPIO,
+) where
+    T: Deref<Target = nrf51::timer0::RegisterBlock>,
+{
+    display.handle_event(&mut MicrobitTimer(timer), &mut MicrobitGpio(gpio));
 }
-

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -119,6 +119,8 @@
 //! Once you've called `set_frame()`, you are free to reuse the
 //! `MicrobitFrame`.
 //!
+//! See [`doc_example`](doc_example/index.html) for a complete working example.
+//!
 //! [dal]: https://lancaster-university.github.io/microbit-docs/
 //! [micropython]: https://microbit-micropython.readthedocs.io/
 //!
@@ -151,6 +153,8 @@ mod microbit_timer;
 pub mod image;
 
 pub use microbit_matrix::MicrobitFrame;
+
+pub mod doc_example;
 
 
 use microbit_control::MicrobitGpio;

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -1,0 +1,211 @@
+//! Support for the 5×5 LED display.
+//!
+//! # Scope
+//!
+//! Together with `tiny-led-matrix`, this module provides:
+//! - support for driving the LED display from a timer interrupt
+//! - ten levels of brightness for each LED
+//! - simple 5×5 greyscale and black-and-white image types.
+//!
+//! The module doesn't define interrupt handlers directly; instead it provides
+//! a function to be called from a timer interrupt. It knows how to program
+//! one of the micro:bit's timers to provide that interrupt.
+//!
+//! # Coordinate system
+//!
+//! The LEDs are identified using (x,y) coordinates as follows:
+//!
+//! ```text
+//! (0,0) ... (4,0)
+//!  ...  ...  ...
+//! (4,0) ... (4,4)
+//! ```
+//!
+//! # Greyscale model
+//!
+//! LED brightness levels are described using a scale from 0 (off) to 9
+//! (brightest) inclusive.
+//!
+//! These are converted to time slices using the same timings as used by the
+//! [micro:bit MicroPython port][micropython] (this is different to the 0 to
+//! 255 scale used by the [micro:bit runtime][dal]).
+//!
+//! The time slice for each level above 1 is approximately 1.9× the slice for
+//! the previous level.
+//!
+//! An LED with brightness 9 is lit for one third of the time (because
+//! internally there are three 'rows' of LEDs which have to be addressed one
+//! at a time).
+//!
+//! # Images and Render
+//!
+//! The [`Render`] trait defines the interface that an image-like type needs
+//! to provide in order to be displayed.
+//!
+//! It contains a single function: [`brightness_at(x,
+//! y)`][display::Render::brightness_at], returning a brightness level.
+//!
+//! The [`image`] submodule provides two static image types implementing
+//! `Render`:
+//! - [`GreyscaleImage`], allowing all 9 levels (using one byte for each LED)
+//! - [`BitImage`], allowing only 'on' and 'off' (using five bytes)
+//!
+//! # Display
+//!
+//! A [`Display`] instance controls the LEDs and programs a timer. There
+//! should normally be a single `Display` instance in the program.
+//!
+//! # Frames
+//!
+//! Types implementing [`Render`] aren't used directly with the [`Display`];
+//! instead they're used to update a [`MicrobitFrame`] instance which is in
+//! turn passed to the `Display`.
+//!
+//! A `MicrobitFrame` instance is a 'compiled' representation of a 5×5
+//! greyscale image, in a form that's more directly usable by the display
+//! code.
+//!
+//! This is exposed in the public API so that you can construct the
+//! `MicrobitFrame` representation in code running at a low priority. Then
+//! only [`Display::set_frame()`] has to be called in code that can't be
+//! interrupted by the display timer.
+//!
+//! # Timer integration
+//!
+//! The `Display` expects to control a single timer. It can use the
+//! micro:bit's `TIMER0`, `TIMER1`, or `TIMER2`.
+//!
+//! This uses a 6ms period to light each of the three internal LED rows, so
+//! that the entire display is updated every 18ms.
+//!
+//! When rendering greyscale images, the `Display` requests extra interrupts
+//! within each 6ms period. It only requests interrupts for the greyscale
+//! levels which are actually required for what's currently being displayed.
+//!
+//! ## Technical details
+//!
+//! The timer is set to 16-bit mode, using a 62.5kHz clock (16 µs ticks). It
+//! resets every 375 ticks.
+//!
+//! The display code uses the CC0 and CC1 capture/compare registers. You are
+//! free to use CC2 and CC3.
+//!
+//! # Usage
+//!
+//! Choose a timer to drive the display from (`TIMER0`, `TIMER1`, or
+//! `TIMER2`).
+//!
+//! When your program starts:
+//! * call [`initialise_display()`], passing it the timer you chose and and
+//! the gpio peripheral
+//! * create a [`Display`] struct (a `Display<MicrobitFrame>`).
+//!
+//! In an interrupt handler for the same timer, call
+//! [`handle_display_event()`].
+//!
+//! To change what's displayed: create a [`MicrobitFrame`] instance, use
+//! [`.set()`](`display::Frame::set()`) to put an image (something implementing
+//! [`Render`]) in it, then call [`Display::set_frame()`]. Note you'll have to
+//! `use microbit::display::Frame` to make `set()` available.
+//!
+//! You can call `set_frame()` at any time, so long as you're not
+//! interrupting, or interruptable by, `handle_display_event()`.
+//!
+//! Once you've called `set_frame()`, you are free to reuse the
+//! `MicrobitFrame`.
+//!
+//! [dal]: https://lancaster-university.github.io/microbit-docs/
+//! [micropython]: https://microbit-micropython.readthedocs.io/
+//!
+//! [`BitImage`]: display::image::BitImage
+//! [`Display`]: display::Display
+//! [`Display::set_frame()`]: display::Display::set_frame
+//! [`Frame`]: display::Frame
+//! [`Matrix`]: display::Matrix
+//! [`MicrobitFrame`]: display::MicrobitFrame
+//! [`Render`]: display::Render
+//! [`image`]: display::image
+//! [`handle_display_event()`]: display::handle_display_event
+//! [`initialise_display()`]: display::initialise_display
+//! [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
+//! [`GreyscaleImage`]: display::image::GreyscaleImage
+//!
+
+#[doc(no_inline)]
+pub use tiny_led_matrix::{
+    Render,
+    MAX_BRIGHTNESS,
+    Display,
+    Frame,
+};
+
+mod microbit_control;
+mod microbit_matrix;
+mod microbit_timer;
+
+pub mod image;
+
+pub use microbit_matrix::MicrobitFrame;
+
+
+use microbit_control::MicrobitGpio;
+
+/// Initialises the micro:bit hardware to use the display driver.
+///
+/// You can use `nrf51::TIMER0`, `nrf51::TIMER1`, or `nrf51::TIMER2` for the
+/// timer parameter.
+///
+/// Assumes the timer and the GPIO port are in the state they would have after
+/// system reset.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut p: nrf51::Peripherals = _;
+/// microbit::display::initialise_display(&mut p.TIMER1, &mut p.GPIO);
+/// ```
+pub fn initialise_display<'a, T>(
+    timer: &'a mut T,
+    gpio: &mut crate::hal::nrf51::GPIO)
+    where T: microbit_timer::Nrf51Timer<'a> {
+    tiny_led_matrix::initialise_control(&mut MicrobitGpio(gpio));
+    tiny_led_matrix::initialise_timer(&mut timer.as_display_timer());
+}
+
+/// Updates the LEDs and timer state during a timer interrupt.
+///
+/// You can use `nrf51::TIMER0`, `nrf51::TIMER1`, or `nrf51::TIMER2` for the
+/// timer parameter (it must be the same timer you used for
+/// [`initialise_display()`]).
+///
+/// Call this in an interrupt handler for the timer you're using.
+///
+/// Takes care of clearing the timer's event registers.
+///
+/// See [`Display::handle_event()`] for details.
+///
+/// # Example
+///
+/// In the style of `cortex-m-rtfm` v0.4:
+///
+/// ```ignore
+/// #[interrupt(priority = 2, resources = [TIMER1, GPIO, DISPLAY])]
+/// fn TIMER1() {
+///     microbit::display::handle_display_event(
+///         &mut resources.DISPLAY,
+///         resources.TIMER1,
+///         resources.GPIO,
+///     );
+/// }
+/// ```
+pub fn handle_display_event<'a, T>(
+    display: &mut Display<MicrobitFrame>,
+    timer: &'a mut T,
+    gpio: &mut crate::hal::nrf51::GPIO)
+    where T: microbit_timer::Nrf51Timer<'a> {
+    display.handle_event(
+        &mut timer.as_display_timer(),
+        &mut MicrobitGpio(gpio),
+    );
+}
+

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -11,6 +11,11 @@
 //! a function to be called from a timer interrupt. It knows how to program
 //! one of the micro:bit's timers to provide that interrupt.
 //!
+//! # Example
+//!
+//! `examples/led_nonblocking.rs` demonstrates the main features of this
+//! module.
+//!
 //! # Coordinate system
 //!
 //! The LEDs are identified using (x,y) coordinates as follows:

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -157,7 +157,10 @@ pub use microbit_matrix::MicrobitFrame;
 pub mod doc_example;
 
 
+use core::ops::Deref;
+use crate::hal::nrf51;
 use microbit_control::MicrobitGpio;
+use microbit_timer::MicrobitTimer;
 
 /// Initialises the micro:bit hardware to use the display driver.
 ///
@@ -176,9 +179,9 @@ use microbit_control::MicrobitGpio;
 pub fn initialise_display<'a, T>(
     timer: &'a mut T,
     gpio: &mut crate::hal::nrf51::GPIO)
-    where T: microbit_timer::Nrf51Timer<'a> {
+    where T: Deref <Target = nrf51::timer0::RegisterBlock> {
     tiny_led_matrix::initialise_control(&mut MicrobitGpio(gpio));
-    tiny_led_matrix::initialise_timer(&mut timer.as_display_timer());
+    tiny_led_matrix::initialise_timer(&mut MicrobitTimer(timer));
 }
 
 /// Updates the LEDs and timer state during a timer interrupt.
@@ -211,9 +214,9 @@ pub fn handle_display_event<'a, T>(
     display: &mut Display<MicrobitFrame>,
     timer: &'a mut T,
     gpio: &mut crate::hal::nrf51::GPIO)
-    where T: microbit_timer::Nrf51Timer<'a> {
+    where T: Deref <Target = nrf51::timer0::RegisterBlock> {
     display.handle_event(
-        &mut timer.as_display_timer(),
+        &mut MicrobitTimer(timer),
         &mut MicrobitGpio(gpio),
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub use crate::hal::nrf51::*;
 use crate::hal::gpio::gpio::Parts;
 use crate::hal::serial::*;
 
+pub mod display;
 pub mod led;
 
 // FIXME: Rewrite as macro to prevent problems consuming parts of gpio


### PR DESCRIPTION
This is the core of the code from <https://github.com/mattheww/microbit-blinkenlights>, as discussed in #13.

I've left out the font and scrolling support to start with.

Notes:

* I haven't done anything with the existing 'blocking' led.rs module.

* The rustdoc is using RFC1946-style links, which aren't stable but do work on docs.rs . I can remove those if you don't want to require nightly rustdoc.

