### PR TITLE
Replaced NVIC::enable with NVIC::unmask

### DIFF
--- a/examples/gpio_hal_printbuttons.rs
+++ b/examples/gpio_hal_printbuttons.rs
@@ -7,9 +7,9 @@ use microbit::hal::nrf51::{interrupt, GPIOTE, UART0};
 use microbit::hal::prelude::*;
 use microbit::hal::serial;
 use microbit::hal::serial::BAUD115200;
+use microbit::NVIC;
 
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use core::cell::RefCell;
@@ -21,10 +21,12 @@ static TX: Mutex<RefCell<Option<serial::Tx<UART0>>>> = Mutex::new(RefCell::new(N
 
 #[entry]
 fn main() -> ! {
-    if let (Some(p), Some(mut cp)) = (microbit::Peripherals::take(), Peripherals::take()) {
+    if let Some(p) = microbit::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             /* Enable external GPIO interrupts */
-            cp.NVIC.enable(microbit::Interrupt::GPIOTE);
+            unsafe {
+                NVIC::unmask(microbit::Interrupt::GPIOTE);
+            }
             microbit::NVIC::unpend(microbit::Interrupt::GPIOTE);
 
             /* Split GPIO pins */

--- a/examples/i2c_direct_printmagserial.rs
+++ b/examples/i2c_direct_printmagserial.rs
@@ -5,9 +5,9 @@ use panic_halt as _;
 
 use microbit::hal::nrf51::*;
 use microbit::hal::nrf51::{interrupt, UART0};
+use microbit::NVIC;
 
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 
 use core::cell::RefCell;
 use core::fmt::Write;
@@ -92,10 +92,10 @@ fn main() -> ! {
             *TWI.borrow(cs).borrow_mut() = Some(p.TWI1);
         });
 
-        if let Some(mut p) = Peripherals::take() {
-            p.NVIC.enable(microbit::Interrupt::RTC0);
-            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+        unsafe {
+            NVIC::unmask(microbit::Interrupt::RTC0);
         }
+        microbit::NVIC::unpend(microbit::Interrupt::RTC0);
     }
 
     loop {

--- a/examples/i2c_hal_printmagserial.rs
+++ b/examples/i2c_hal_printmagserial.rs
@@ -8,9 +8,9 @@ use microbit::hal::nrf51::{interrupt, RTC0, TWI1, UART0};
 use microbit::hal::prelude::*;
 use microbit::hal::serial;
 use microbit::hal::serial::BAUD115200;
+use microbit::NVIC;
 
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 
 use core::cell::RefCell;
 use core::fmt::Write;
@@ -63,11 +63,10 @@ fn main() -> ! {
             *I2C.borrow(cs).borrow_mut() = Some(i2c);
             *TX.borrow(cs).borrow_mut() = Some(tx);
         });
-
-        if let Some(mut p) = Peripherals::take() {
-            p.NVIC.enable(microbit::Interrupt::RTC0);
-            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+        unsafe {
+            NVIC::unmask(microbit::Interrupt::RTC0);
         }
+        microbit::NVIC::unpend(microbit::Interrupt::RTC0);
     }
 
     loop {

--- a/examples/i2c_haldriver_printmagserial.rs
+++ b/examples/i2c_haldriver_printmagserial.rs
@@ -10,10 +10,10 @@ use microbit::hal::nrf51::{interrupt, GPIOTE, UART0};
 use microbit::hal::prelude::*;
 use microbit::hal::serial;
 use microbit::hal::serial::BAUD115200;
+use microbit::NVIC;
 use microbit::TWI1;
 
 use crate::cortex_m::interrupt::Mutex;
-use crate::cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use mag3110::{DataRate, Mag3110, Oversampling};
@@ -28,10 +28,12 @@ static MAG3110: Mutex<RefCell<Option<Mag3110<I2c<TWI1>>>>> = Mutex::new(RefCell:
 
 #[entry]
 fn main() -> ! {
-    if let (Some(p), Some(mut cp)) = (microbit::Peripherals::take(), Peripherals::take()) {
+    if let Some(p) = microbit::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             /* Enable external GPIO interrupts */
-            cp.NVIC.enable(microbit::Interrupt::GPIOTE);
+            unsafe {
+                NVIC::unmask(microbit::Interrupt::GPIOTE);
+            }
             microbit::NVIC::unpend(microbit::Interrupt::GPIOTE);
 
             /* Set up pin 29 to act as external interrupt from the magnetometer */

--- a/examples/rng_direct_printrngserial.rs
+++ b/examples/rng_direct_printrngserial.rs
@@ -3,8 +3,9 @@
 
 use panic_halt as _;
 
+use microbit::NVIC;
+
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 use microbit::hal::nrf51::{interrupt, RNG, RTC0, UART0};
 
 use core::cell::RefCell;
@@ -56,10 +57,10 @@ fn main() -> ! {
             *UART.borrow(cs).borrow_mut() = Some(p.UART0);
         });
 
-        if let Some(mut p) = Peripherals::take() {
-            p.NVIC.enable(microbit::Interrupt::RTC0);
-            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+        unsafe {
+            NVIC::unmask(microbit::Interrupt::RTC0);
         }
+        microbit::NVIC::unpend(microbit::Interrupt::RTC0);
     }
 
     loop {

--- a/examples/rng_hal_printrandserial.rs
+++ b/examples/rng_hal_printrandserial.rs
@@ -9,9 +9,9 @@ use microbit::hal::prelude::*;
 use microbit::hal::rng;
 use microbit::hal::serial;
 use microbit::hal::serial::BAUD115200;
+use microbit::NVIC;
 
 use cortex_m::interrupt::Mutex;
-use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 use rand::SeedableRng;
@@ -67,10 +67,10 @@ fn main() -> ! {
             *RTC.borrow(cs).borrow_mut() = Some(p.RTC0);
             *TX.borrow(cs).borrow_mut() = Some(tx);
 
-            if let Some(mut p) = Peripherals::take() {
-                p.NVIC.enable(microbit::Interrupt::RTC0);
-                microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+            unsafe {
+                NVIC::unmask(microbit::Interrupt::RTC0);
             }
+            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
         });
     }
 


### PR DESCRIPTION
This removes all usages of the deprecated `NVIC::enable` and replaces them with `NVIC::unmask`.
According to upstream `NVIC::enable` has a soundness issue and should be marked unsafe, which is why it was deprecated.

Fixes #18 