### PR TITLE
Add GitHub actions CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          target: thumbv6m-none-eabi
+          override: true
+          components: rustfmt, clippy
+
+      - name: rustfmt
+        run: cargo fmt -- --check
+
+      - name: clippy
+        run: cargo clippy --color=always -- -D warnings
+
+      - name: build
+        run: cargo check
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 **/*.rs.bk
 Cargo.lock
 bloat_log*
+!.gitignore
+!.github

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
-microbit
-========
+# microbit
+
+[![microbit on crates.io][cratesio-image]][cratesio]
+[![microbit on docs.rs][docsrs-image]][docsrs]
+
+[cratesio-image]: https://img.shields.io/crates/v/microbit.svg
+[cratesio]: https://crates.io/crates/microbit
+[docsrs-image]: https://docs.rs/microbit/badge.svg
+[docsrs]: https://docs.rs/microbit
 
 _microbit_ contains everything required to get started with the use of Rust to create firmwares for the fabulous [BBC micro:bit][] microcontroller board. This little board has everything and a kitchen sink built-in, even a capable debugging interface, so all that one needs to get going with programming this device is:
 
@@ -18,7 +25,6 @@ A guide to embedded development with Rust on the _microbit_ using this crate can
 [myblog]: https://www.eggers-club.de/blog/2018/05/31/rust-on-the-microbit-101-part-1
 [microrust]: https://droogmic.github.io/microrust/
 
-License
--------
+## License
 
 [0-clause BSD license](LICENSE-0BSD.txt).

--- a/examples/led_nonblocking.rs
+++ b/examples/led_nonblocking.rs
@@ -29,7 +29,8 @@ fn heart_image(inner_brightness: u8) -> GreyscaleImage {
 
 static GPIO: Mutex<RefCell<Option<GPIO>>> = Mutex::new(RefCell::new(None));
 static ANIM_TIMER: Mutex<RefCell<Option<LoResTimer<RTC0>>>> = Mutex::new(RefCell::new(None));
-static DISPLAY_TIMER: Mutex<RefCell<Option<MicrobitDisplayTimer<TIMER1>>>> = Mutex::new(RefCell::new(None));
+static DISPLAY_TIMER: Mutex<RefCell<Option<MicrobitDisplayTimer<TIMER1>>>> =
+    Mutex::new(RefCell::new(None));
 static DISPLAY: Mutex<RefCell<Option<Display<MicrobitFrame>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]

--- a/src/display/image.rs
+++ b/src/display/image.rs
@@ -76,7 +76,7 @@ impl BitImage {
         // FIXME: can we reject values other than 0 or 1?
         const fn row_byte(row: [u8; 5]) -> u8 {
             row[0] | row[1] << 1 | row[2] << 2 | row[3] << 3 | row[4] << 4
-        };
+        }
         BitImage([
             row_byte(im[0]),
             row_byte(im[1]),

--- a/src/led.rs
+++ b/src/led.rs
@@ -8,6 +8,7 @@ use crate::hal::gpio::gpio::{
 use crate::hal::gpio::{Output, PushPull};
 use crate::hal::prelude::*;
 
+#[allow(clippy::upper_case_acronyms)]
 type LED = PIN<Output<PushPull>>;
 
 const DEFAULT_DELAY_MS: u32 = 2;
@@ -28,6 +29,7 @@ pub struct Display {
 
 impl Display {
     /// Initializes all the user LEDs
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         col1: PIN4<Output<PushPull>>,
         col2: PIN5<Output<PushPull>>,


### PR DESCRIPTION
This adds a basic GitHub actions CI workflow. It includes `rustfmt`, `clippy` and `check`. The CI will not run on this PR because I'm opening it from a fork. If you would like to see it running before merging it you could push the branch to your repo and open a PR.

I have also added badges for crates.io and docs.rs as I often find them useful. If the CI proves useful I can add badge for that as well.