### PR TITLE
Upgrade nrf51-hal to 0.12.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,23 +23,42 @@ version = "0.8.0"
 cortex-m = "0.6.1"
 cortex-m-rt = "0.6.10"
 nb = "0.1.2"
-nrf51-hal = "0.7.0"
+nrf51-hal = "0.12.1"
 tiny-led-matrix = "1.0.1"
+embedded-hal = "0.2.4"
+
+defmt = "0.1.3"
 
 [dev-dependencies]
-cortex-m-semihosting = "0.3.5"
 numtoa = "0.2.3"
 dcf77 = "0.1.0"
 mag3110 = "0.1.4"
 panic-halt = "0.2.0"
-cortex-m-rtfm = "0.5"
+cortex-m-rtic = "0.5"
+defmt-rtt = "0.1.0"
+panic-probe = { version = "0.1.0", features = ["print-defmt"] }
+
+[features]
+# set logging levels here
+default = [
+  "defmt-default",
+  # "dependency-a/defmt-trace",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []
 
 [dev-dependencies.rand]
 default-features = false
-version = "0.7.2"
+version = "0.8.3"
 
 [dev-dependencies.rand_chacha]
-version = "0.2.1"
+version = "0.3.0"
 default-features = false
 
 [profile.dev]

--- a/examples/gpio_direct_blinky.rs
+++ b/examples/gpio_direct_blinky.rs
@@ -23,7 +23,7 @@ fn main() -> ! {
                 p.GPIO.out.write(|w| unsafe { w.bits(0) });
             }
 
-            for _ in 0..1_000_000 {
+            for _ in 0..50_000 {
                 cortex_m::asm::nop();
             }
         }

--- a/examples/gpio_hal_blinky.rs
+++ b/examples/gpio_hal_blinky.rs
@@ -3,24 +3,28 @@
 
 use panic_halt as _;
 
-use microbit::hal::delay::Delay;
-use microbit::hal::prelude::*;
-
 use cortex_m_rt::entry;
+use embedded_hal::{blocking::delay::DelayMs, digital::v2::OutputPin};
+use microbit::hal::{
+    gpio::{p0, Level},
+    timer::Timer,
+};
 
 #[entry]
 fn main() -> ! {
     if let Some(p) = microbit::Peripherals::take() {
-        let gpio = p.GPIO.split();
-        let mut delay = Delay::new(p.TIMER0);
-        let mut led = gpio.pin13.into_push_pull_output();
-        let _ = gpio.pin4.into_push_pull_output();
+        /* Split GPIO pins */
+        let gpio = p0::Parts::new(p.GPIO);
+
+        let mut timer = Timer::new(p.TIMER0);
+        let mut led = gpio.p0_13.into_push_pull_output(Level::Low);
+        let _ = gpio.p0_04.into_push_pull_output(Level::Low);
 
         loop {
             let _ = led.set_low();
-            delay.delay_ms(1_000_u16);
+            timer.delay_ms(1_000_u16);
             let _ = led.set_high();
-            delay.delay_ms(1_000_u16);
+            timer.delay_ms(1_000_u16);
         }
     }
 

--- a/examples/gpio_hal_ledbutton.rs
+++ b/examples/gpio_hal_ledbutton.rs
@@ -4,24 +4,24 @@
 use panic_halt as _;
 
 use cortex_m_rt::entry;
-use microbit::hal::prelude::*;
+use microbit::hal::{self, gpio::Level, prelude::*};
 
 #[entry]
 fn main() -> ! {
     if let Some(p) = microbit::Peripherals::take() {
         // Split GPIO pins
-        let gpio = p.GPIO.split();
+        let gpio = hal::gpio::p0::Parts::new(p.GPIO);
 
         // Set row of LED matrix to permanent high
-        let _ = gpio.pin13.into_push_pull_output().set_high();
+        let _ = gpio.p0_13.into_push_pull_output(Level::Low).set_high();
 
         // Set 2 columns to output to control LED states
-        let mut led1 = gpio.pin4.into_push_pull_output();
-        let mut led2 = gpio.pin6.into_push_pull_output();
+        let mut led1 = gpio.p0_04.into_push_pull_output(Level::Low);
+        let mut led2 = gpio.p0_06.into_push_pull_output(Level::Low);
 
         // Configure button GPIOs as inputs
-        let button_a = gpio.pin17.into_floating_input();
-        let button_b = gpio.pin26.into_floating_input();
+        let button_a = gpio.p0_17.into_floating_input();
+        let button_b = gpio.p0_26.into_floating_input();
 
         loop {
             if let Ok(true) = button_a.is_high() {

--- a/examples/i2c_direct_printmagserial.rs
+++ b/examples/i2c_direct_printmagserial.rs
@@ -3,19 +3,15 @@
 
 use panic_halt as _;
 
-use microbit::hal::nrf51::*;
-use microbit::hal::nrf51::{interrupt, UART0};
-use microbit::NVIC;
+use core::{cell::RefCell, fmt::Write};
 
 use cortex_m::interrupt::Mutex;
-
-use core::cell::RefCell;
-use core::fmt::Write;
 use cortex_m_rt::entry;
+use microbit::pac::{self, interrupt};
 
-static RTC: Mutex<RefCell<Option<RTC0>>> = Mutex::new(RefCell::new(None));
-static UART: Mutex<RefCell<Option<UART0>>> = Mutex::new(RefCell::new(None));
-static TWI: Mutex<RefCell<Option<TWI1>>> = Mutex::new(RefCell::new(None));
+static RTC: Mutex<RefCell<Option<pac::RTC0>>> = Mutex::new(RefCell::new(None));
+static UART: Mutex<RefCell<Option<pac::UART0>>> = Mutex::new(RefCell::new(None));
+static TWI: Mutex<RefCell<Option<pac::TWI1>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
@@ -93,9 +89,9 @@ fn main() -> ! {
         });
 
         unsafe {
-            NVIC::unmask(microbit::Interrupt::RTC0);
+            pac::NVIC::unmask(pac::Interrupt::RTC0);
         }
-        microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+        pac::NVIC::unpend(pac::Interrupt::RTC0);
     }
 
     loop {
@@ -166,7 +162,7 @@ fn RTC0() {
     }
 }
 
-pub struct UART0Buffer<'a>(pub &'a UART0);
+pub struct UART0Buffer<'a>(pub &'a pac::UART0);
 
 impl<'a> core::fmt::Write for UART0Buffer<'a> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {

--- a/examples/led_blocking.rs
+++ b/examples/led_blocking.rs
@@ -1,34 +1,38 @@
 #![no_std]
 #![no_main]
 
+use defmt_rtt as _;
 use panic_halt as _;
 
 use cortex_m_rt::entry;
 
-use microbit::hal::delay::Delay;
-use microbit::hal::prelude::*;
+use microbit::hal::{
+    gpio::{p0::Parts as P0Parts, Level},
+    prelude::*,
+    Timer,
+};
 
 use microbit::led;
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = microbit::Peripherals::take() {
-        let gpio = p.GPIO.split();
-        let mut delay = Delay::new(p.TIMER0);
+    if let Some(p) = microbit::pac::Peripherals::take() {
+        let mut timer = Timer::new(p.TIMER0);
+        let p0parts = P0Parts::new(p.GPIO);
 
         // Display
-        let row1 = gpio.pin13.into_push_pull_output();
-        let row2 = gpio.pin14.into_push_pull_output();
-        let row3 = gpio.pin15.into_push_pull_output();
-        let col1 = gpio.pin4.into_push_pull_output();
-        let col2 = gpio.pin5.into_push_pull_output();
-        let col3 = gpio.pin6.into_push_pull_output();
-        let col4 = gpio.pin7.into_push_pull_output();
-        let col5 = gpio.pin8.into_push_pull_output();
-        let col6 = gpio.pin9.into_push_pull_output();
-        let col7 = gpio.pin10.into_push_pull_output();
-        let col8 = gpio.pin11.into_push_pull_output();
-        let col9 = gpio.pin12.into_push_pull_output();
+        let row1 = p0parts.p0_13.into_push_pull_output(Level::Low);
+        let row2 = p0parts.p0_14.into_push_pull_output(Level::Low);
+        let row3 = p0parts.p0_15.into_push_pull_output(Level::Low);
+        let col1 = p0parts.p0_04.into_push_pull_output(Level::Low);
+        let col2 = p0parts.p0_05.into_push_pull_output(Level::Low);
+        let col3 = p0parts.p0_06.into_push_pull_output(Level::Low);
+        let col4 = p0parts.p0_07.into_push_pull_output(Level::Low);
+        let col5 = p0parts.p0_08.into_push_pull_output(Level::Low);
+        let col6 = p0parts.p0_09.into_push_pull_output(Level::Low);
+        let col7 = p0parts.p0_10.into_push_pull_output(Level::Low);
+        let col8 = p0parts.p0_11.into_push_pull_output(Level::Low);
+        let col9 = p0parts.p0_12.into_push_pull_output(Level::Low);
         let mut leds = led::Display::new(
             col1, col2, col3, col4, col5, col6, col7, col8, col9, row1, row2, row3,
         );
@@ -86,14 +90,14 @@ fn main() -> ! {
             [0, 0, 1, 0, 0],
         ];
         loop {
-            leds.display(&mut delay, letter_I, 1000);
-            leds.display(&mut delay, heart, 1000);
-            leds.display(&mut delay, letter_R, 1000);
-            leds.display(&mut delay, letter_u, 1000);
-            leds.display(&mut delay, letter_s, 1000);
-            leds.display(&mut delay, letter_t, 1000);
+            leds.display(&mut timer, letter_I, 1000);
+            leds.display(&mut timer, heart, 1000);
+            leds.display(&mut timer, letter_R, 1000);
+            leds.display(&mut timer, letter_u, 1000);
+            leds.display(&mut timer, letter_s, 1000);
+            leds.display(&mut timer, letter_t, 1000);
             leds.clear();
-            delay.delay_ms(250_u32);
+            timer.delay_ms(250_u32);
         }
     }
 

--- a/examples/led_nonblocking.rs
+++ b/examples/led_nonblocking.rs
@@ -1,6 +1,7 @@
 #![no_main]
 #![no_std]
 
+use defmt_rtt as _;
 use panic_halt as _;
 
 use core::cell::RefCell;
@@ -8,10 +9,11 @@ use cortex_m::interrupt::Mutex;
 use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
-use microbit::display::image::GreyscaleImage;
-use microbit::display::{self, Display, Frame, MicrobitDisplayTimer, MicrobitFrame};
-use microbit::hal::lo_res_timer::{LoResTimer, FREQ_16HZ};
-use microbit::hal::nrf51::{interrupt, GPIO, RTC0, TIMER1};
+use microbit::{
+    display::{self, image::GreyscaleImage, Display, Frame, MicrobitDisplayTimer, MicrobitFrame},
+    hal::rtc::{Rtc, RtcInterrupt},
+    pac::{self, interrupt, GPIO, RTC0, TIMER1},
+};
 
 fn heart_image(inner_brightness: u8) -> GreyscaleImage {
     let b = inner_brightness;
@@ -28,26 +30,26 @@ fn heart_image(inner_brightness: u8) -> GreyscaleImage {
 // We set the TIMER1 interrupt to a higher priority than RTC0.
 
 static GPIO: Mutex<RefCell<Option<GPIO>>> = Mutex::new(RefCell::new(None));
-static ANIM_TIMER: Mutex<RefCell<Option<LoResTimer<RTC0>>>> = Mutex::new(RefCell::new(None));
+static ANIM_TIMER: Mutex<RefCell<Option<Rtc<RTC0>>>> = Mutex::new(RefCell::new(None));
 static DISPLAY_TIMER: Mutex<RefCell<Option<MicrobitDisplayTimer<TIMER1>>>> =
     Mutex::new(RefCell::new(None));
 static DISPLAY: Mutex<RefCell<Option<Display<MicrobitFrame>>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = microbit::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         // Starting the low-frequency clock (needed for RTC to work)
         p.CLOCK.tasks_lfclkstart.write(|w| unsafe { w.bits(1) });
         while p.CLOCK.events_lfclkstarted.read().bits() == 0 {}
         p.CLOCK.events_lfclkstarted.reset();
 
         cortex_m::interrupt::free(move |cs| {
-            let mut rtc0 = LoResTimer::new(p.RTC0);
+            // RTC at 16Hz (32_768 / (2047 + 1))
             // 62.5ms period
-            rtc0.set_frequency(FREQ_16HZ);
-            rtc0.enable_tick_event();
-            rtc0.enable_tick_interrupt();
-            rtc0.start();
+            let mut rtc0 = Rtc::new(p.RTC0, 2047).unwrap();
+            rtc0.enable_event(RtcInterrupt::Tick);
+            rtc0.enable_interrupt(RtcInterrupt::Tick, None);
+            rtc0.enable_counter();
 
             let mut timer = MicrobitDisplayTimer::new(p.TIMER1);
             let mut gpio = p.GPIO;
@@ -59,13 +61,11 @@ fn main() -> ! {
         });
         if let Some(mut cp) = Peripherals::take() {
             unsafe {
-                cp.NVIC.set_priority(microbit::Interrupt::RTC0, 64);
-                cp.NVIC.set_priority(microbit::Interrupt::TIMER1, 128);
+                cp.NVIC.set_priority(pac::Interrupt::RTC0, 64);
+                cp.NVIC.set_priority(pac::Interrupt::TIMER1, 128);
+                pac::NVIC::unmask(pac::Interrupt::RTC0);
+                pac::NVIC::unmask(pac::Interrupt::TIMER1);
             }
-            cp.NVIC.enable(microbit::Interrupt::RTC0);
-            cp.NVIC.enable(microbit::Interrupt::TIMER1);
-            microbit::NVIC::unpend(microbit::Interrupt::RTC0);
-            microbit::NVIC::unpend(microbit::Interrupt::TIMER1);
         }
     }
 
@@ -88,13 +88,13 @@ fn TIMER1() {
 }
 
 #[interrupt]
-fn RTC0() {
+unsafe fn RTC0() {
     static mut STEP: u8 = 0;
     static mut FRAME: MicrobitFrame = MicrobitFrame::const_default();
 
     cortex_m::interrupt::free(|cs| {
         if let Some(rtc) = ANIM_TIMER.borrow(cs).borrow_mut().as_mut() {
-            rtc.clear_tick_event();
+            rtc.reset_event(RtcInterrupt::Tick);
         }
     });
 
@@ -104,7 +104,7 @@ fn RTC0() {
         _ => unreachable!(),
     };
 
-    FRAME.set(&mut heart_image(inner_brightness));
+    FRAME.set(&heart_image(inner_brightness));
 
     cortex_m::interrupt::free(|cs| {
         if let Some(d) = DISPLAY.borrow(cs).borrow_mut().as_mut() {

--- a/examples/rng_direct_printrngserial.rs
+++ b/examples/rng_direct_printrngserial.rs
@@ -3,18 +3,17 @@
 
 use panic_halt as _;
 
-use microbit::NVIC;
+use microbit::pac::{self, interrupt};
 
 use cortex_m::interrupt::Mutex;
-use microbit::hal::nrf51::{interrupt, RNG, RTC0, UART0};
 
 use core::cell::RefCell;
 use core::fmt::Write;
 use cortex_m_rt::entry;
 
-static RNG: Mutex<RefCell<Option<RNG>>> = Mutex::new(RefCell::new(None));
-static RTC: Mutex<RefCell<Option<RTC0>>> = Mutex::new(RefCell::new(None));
-static UART: Mutex<RefCell<Option<UART0>>> = Mutex::new(RefCell::new(None));
+static RNG: Mutex<RefCell<Option<pac::RNG>>> = Mutex::new(RefCell::new(None));
+static RTC: Mutex<RefCell<Option<pac::RTC0>>> = Mutex::new(RefCell::new(None));
+static UART: Mutex<RefCell<Option<pac::UART0>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
@@ -58,9 +57,9 @@ fn main() -> ! {
         });
 
         unsafe {
-            NVIC::unmask(microbit::Interrupt::RTC0);
+            pac::NVIC::unmask(pac::Interrupt::RTC0);
         }
-        microbit::NVIC::unpend(microbit::Interrupt::RTC0);
+        pac::NVIC::unpend(pac::Interrupt::RTC0);
     }
 
     loop {
@@ -97,7 +96,7 @@ fn RTC0() {
     });
 }
 
-pub struct UART0Buffer<'a>(pub &'a UART0);
+pub struct UART0Buffer<'a>(pub &'a pac::UART0);
 
 impl<'a> core::fmt::Write for UART0Buffer<'a> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {

--- a/examples/serial_direct_echo.rs
+++ b/examples/serial_direct_echo.rs
@@ -52,7 +52,7 @@ fn main() -> ! {
     }
 }
 
-fn write_uart0(uart0: &microbit::hal::nrf51::UART0, s: &str) -> core::fmt::Result {
+fn write_uart0(uart0: &microbit::pac::UART0, s: &str) -> core::fmt::Result {
     /* Start UART sender */
     uart0.tasks_starttx.write(|w| unsafe { w.bits(1) });
 

--- a/examples/serial_direct_helloworld.rs
+++ b/examples/serial_direct_helloworld.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
     }
 }
 
-fn write_uart0(uart0: &microbit::hal::nrf51::UART0, s: &str) -> core::fmt::Result {
+fn write_uart0(uart0: &microbit::pac::UART0, s: &str) -> core::fmt::Result {
     uart0.tasks_starttx.write(|w| unsafe { w.bits(1) });
     for c in s.as_bytes() {
         /* Write the current character to the output register */

--- a/examples/serial_hal_blocking_echo.rs
+++ b/examples/serial_hal_blocking_echo.rs
@@ -3,30 +3,30 @@
 
 use panic_halt as _;
 
+use microbit::hal;
 use microbit::hal::prelude::*;
-use microbit::hal::serial::BAUD115200;
+use microbit::hal::uart::Baudrate;
 
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
     if let Some(p) = microbit::Peripherals::take() {
-        /* Split GPIO pins */
-        let gpio = p.GPIO.split();
+        let gpio = hal::gpio::p0::Parts::new(p.GPIO);
 
         /* Initialise serial port on the micro:bit */
-        let (mut tx, mut rx) = microbit::serial_port!(gpio, p.UART0, BAUD115200);
+        let mut serial = microbit::serial_port!(gpio, p.UART0, Baudrate::BAUD115200);
 
         /* Print a nice hello message */
         let s = b"Please type characters to echo:\r\n";
 
-        let _ = s.iter().map(|c| nb::block!(tx.write(*c))).last();
+        let _ = s.iter().map(|c| nb::block!(serial.write(*c))).last();
 
         /* Endless loop */
         loop {
             /* Read and echo back */
-            if let Ok(c) = nb::block!(rx.read()) {
-                let _ = nb::block!(tx.write(c));
+            if let Ok(c) = nb::block!(serial.read()) {
+                let _ = nb::block!(serial.write(c));
             }
         }
     }

--- a/src/display/control.rs
+++ b/src/display/control.rs
@@ -4,7 +4,7 @@
 //!
 //! [`DisplayControl`]: tiny_led_matrix::DisplayControl
 
-use crate::hal::nrf51;
+use crate::pac;
 use tiny_led_matrix::DisplayControl;
 
 const fn bit_range(lo: usize, count: usize) -> u32 {
@@ -26,7 +26,7 @@ const ROW_BITS: u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
 /// This implements the `DisplayControl` trait.
 ///
 /// [`DisplayControl`]: tiny_led_matrix::DisplayControl
-pub(crate) struct MicrobitGpio<'a>(pub &'a nrf51::GPIO);
+pub(crate) struct MicrobitGpio<'a>(pub &'a pac::GPIO);
 
 /// Returns the GPIO pin numbers corresponding to the columns in a ColumnSet.
 fn column_pins(cols: u32) -> u32 {

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -150,7 +150,8 @@ pub mod image;
 pub use matrix::MicrobitFrame;
 pub use timer::MicrobitDisplayTimer;
 
-use crate::hal::hi_res_timer::Nrf51Timer;
+use crate::hal::timer::Instance;
+
 use control::MicrobitGpio;
 
 /// Initialises the micro:bit hardware to use the display driver.
@@ -164,9 +165,9 @@ use control::MicrobitGpio;
 /// let mut timer = microbit::display::MicrobitDisplayTimer::new(p.TIMER1);
 /// microbit::display::initialise_display(&mut timer, &mut p.GPIO);
 /// ```
-pub fn initialise_display<T: Nrf51Timer>(
+pub fn initialise_display<T: Instance>(
     timer: &mut MicrobitDisplayTimer<T>,
-    gpio: &mut crate::hal::nrf51::GPIO,
+    gpio: &mut crate::pac::GPIO,
 ) {
     tiny_led_matrix::initialise_control(&mut MicrobitGpio(gpio));
     tiny_led_matrix::initialise_timer(timer);
@@ -198,10 +199,10 @@ pub fn initialise_display<T: Nrf51Timer>(
 ///     );
 /// }
 /// ```
-pub fn handle_display_event<T: Nrf51Timer>(
+pub fn handle_display_event<T: Instance>(
     display: &mut Display<MicrobitFrame>,
     timer: &mut MicrobitDisplayTimer<T>,
-    gpio: &mut crate::hal::nrf51::GPIO,
+    gpio: &mut crate::pac::GPIO,
 ) {
     display.handle_event(timer, &mut MicrobitGpio(gpio));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 #![no_std]
 #![allow(non_camel_case_types)]
 
+pub use hal::pac;
+pub use hal::pac::Peripherals;
 pub use nrf51_hal as hal;
 
 pub use nb::*;
-
-pub use crate::hal::nrf51::*;
 
 pub mod display;
 pub mod led;
@@ -13,14 +13,17 @@ pub mod led;
 #[macro_export]
 macro_rules! serial_port {
     ( $gpio:expr, $uart:expr, $speed:expr ) => {{
-        use nrf51_hal::serial::Serial;
+        use microbit::hal::{gpio::Level, uart};
 
         /* Configure RX and TX pins accordingly */
-        let tx = $gpio.pin24.into_push_pull_output().into();
-        let rx = $gpio.pin25.into_floating_input().into();
+        let pins = uart::Pins {
+            rxd: $gpio.p0_25.into_floating_input().degrade(),
+            txd: $gpio.p0_24.into_push_pull_output(Level::Low).degrade(),
+            cts: None,
+            rts: None,
+        };
 
         /* Set up serial port using the prepared pins */
-        let serial = Serial::uart0($uart, tx, rx, $speed);
-        serial.split()
+        uart::Uart::new($uart, pins, uart::Parity::EXCLUDED, $speed)
     }};
 }


### PR DESCRIPTION
Relates to #27 

This is a large change down to the nrf51-hal API changing significantly between 0.7 and 0.10. While the upstream changes are significant I have tried to keep changes to the APIs published from this crate to a minimum. One exception to this is what is re-exported. I'm new to this domain so if the details I've provided aren't useful or there is useful information I haven't provided please let me know.

## Changes to re-exports
To make it easier to transition to supporting both the v1 and v2 microbits I have slightly tweaked the re-exports.
- `nrf51-hal` is still re-exported as `hal`
- `nrf51-hal::pac` is now re-exported as `pac`
- `nrf51-hal::nrf51::*` is no longer re-exported

## The library

### `nrf51_hal::timer`
This is the biggest change. The new timer interface is significantly stripped back so all of the interrupt and compare config in `microbit::display::timer` now have to be done directly on the PAC. 

A gotcha I hit here was that on the nrf51 all but the first timer seem to only be 16 bit.

While the implementation has changed significantly here the public interface has not changed.

### `nrf51_hal::gpio`
How the pins are accessed and how they are named has changed however at the end of the day, they're still GPIO pins so it's not too difficult.

The external interface has changed slightly around these.

### `nrf51_hal::twi`
The name has changed, arguments are slightly different and you have to pass the frequency explicitly now. Other than that it seems the same.

### `nrf51_hal::uart`
The name has changed, arguments are slightly different and you have to pass whether the parity bit is included explicitly now. There doesn't seem to be a way to split it into separate read and write parts but for the examples that didn't seem to be a problem.

## The examples
I have updated all examples to compile and tried to run them however not all of them work.

### Fully working
- `gpio_direct_blinky.rs`
- `gpio_hal_blinky.rs`
- `gpio_hal_ledbutton.rs`
- `gpio_hal_printbuttons.rs`
- `led_blocking.rs`
- `led_nonblocking.rs` (it's a bit flickery but it was before, I'll look at that separately)
- `led_rtfm.rs`
- `rng_direct_printrngserial.rs`
- `serial_direct_echo.rs`
- `serial_direct_helloworld.rs`
- `serial_hal_blocking_echo.rs`

### Not working
None of these work for me on this branch or on master. I would appreciate someone who has them working on master testing them for me.

- `rng_hal_printrandserial.rs`: crashes on line 84 at `rng.next_u32()`.
- `gpio_hal_receivedcf77.rs`: just get a zero timestamp.

I believe all these are failing because I have v1.5 see #9
- `i2c_direct_printmagserial.rs`
- `i2c_hal_printmagserial.rs`
- `i2c_haldriver_printmagserial.rs`