### PR TITLE
Add GPIO pin names and extract LED pins

### DIFF
--- a/examples/led_blocking.rs
+++ b/examples/led_blocking.rs
@@ -21,21 +21,21 @@ fn main() -> ! {
         let p0parts = P0Parts::new(p.GPIO);
 
         // Display
-        let row1 = p0parts.p0_13.into_push_pull_output(Level::Low);
-        let row2 = p0parts.p0_14.into_push_pull_output(Level::Low);
-        let row3 = p0parts.p0_15.into_push_pull_output(Level::Low);
-        let col1 = p0parts.p0_04.into_push_pull_output(Level::Low);
-        let col2 = p0parts.p0_05.into_push_pull_output(Level::Low);
-        let col3 = p0parts.p0_06.into_push_pull_output(Level::Low);
-        let col4 = p0parts.p0_07.into_push_pull_output(Level::Low);
-        let col5 = p0parts.p0_08.into_push_pull_output(Level::Low);
-        let col6 = p0parts.p0_09.into_push_pull_output(Level::Low);
-        let col7 = p0parts.p0_10.into_push_pull_output(Level::Low);
-        let col8 = p0parts.p0_11.into_push_pull_output(Level::Low);
-        let col9 = p0parts.p0_12.into_push_pull_output(Level::Low);
-        let mut leds = led::Display::new(
-            col1, col2, col3, col4, col5, col6, col7, col8, col9, row1, row2, row3,
-        );
+        let pins = led::Pins {
+            row1: p0parts.p0_13.into_push_pull_output(Level::Low),
+            row2: p0parts.p0_14.into_push_pull_output(Level::Low),
+            row3: p0parts.p0_15.into_push_pull_output(Level::Low),
+            col1: p0parts.p0_04.into_push_pull_output(Level::Low),
+            col2: p0parts.p0_05.into_push_pull_output(Level::Low),
+            col3: p0parts.p0_06.into_push_pull_output(Level::Low),
+            col4: p0parts.p0_07.into_push_pull_output(Level::Low),
+            col5: p0parts.p0_08.into_push_pull_output(Level::Low),
+            col6: p0parts.p0_09.into_push_pull_output(Level::Low),
+            col7: p0parts.p0_10.into_push_pull_output(Level::Low),
+            col8: p0parts.p0_11.into_push_pull_output(Level::Low),
+            col9: p0parts.p0_12.into_push_pull_output(Level::Low),
+        };
+        let mut leds = led::Display::new(pins);
 
         #[allow(non_snake_case)]
         let letter_I = [

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1,0 +1,72 @@
+//! Named GPIO pin types
+//!
+//! This module maps the GPIO pin names as described in the
+//! [v1.5 schematic](https://github.com/bbcmicrobit/hardware/tree/master/V1.5).
+//! Where appropriate the pins are restricted with the appropriate `MODE`
+//! from `nrf-hal`.
+#![allow(clippy::upper_case_acronyms)]
+use crate::hal::gpio::{p0, Floating, Input, Output, PushPull};
+
+/* GPIO pads */
+pub type PAD1<MODE> = p0::P0_03<MODE>;
+pub type PAD2<MODE> = p0::P0_02<MODE>;
+pub type PAD3<MODE> = p0::P0_01<MODE>;
+
+/* LED display */
+pub type COL1 = p0::P0_04<Output<PushPull>>;
+pub type COL2 = p0::P0_05<Output<PushPull>>;
+pub type COL3 = p0::P0_06<Output<PushPull>>;
+pub type COL4 = p0::P0_07<Output<PushPull>>;
+pub type COL5 = p0::P0_08<Output<PushPull>>;
+pub type COL6 = p0::P0_09<Output<PushPull>>;
+pub type COL7 = p0::P0_10<Output<PushPull>>;
+pub type COL8 = p0::P0_11<Output<PushPull>>;
+pub type COL9 = p0::P0_12<Output<PushPull>>;
+
+pub type ROW1 = p0::P0_13<Output<PushPull>>;
+pub type ROW2 = p0::P0_14<Output<PushPull>>;
+pub type ROW3 = p0::P0_15<Output<PushPull>>;
+
+/* buttons */
+pub type BTN_A = p0::P0_17<Input<Floating>>;
+pub type BTN_B = p0::P0_26<Input<Floating>>;
+
+/* spi */
+pub type MOSI<MODE> = p0::P0_21<MODE>;
+pub type MISO<MODE> = p0::P0_22<MODE>;
+pub type SCK<MODE> = p0::P0_23<MODE>;
+
+/* i2c */
+pub type SCL = p0::P0_00<Input<Floating>>;
+pub type SDA = p0::P0_30<Input<Floating>>;
+
+/* uart */
+pub type UART_TX = p0::P0_24<Output<PushPull>>;
+pub type UART_RX = p0::P0_25<Input<Floating>>;
+
+/* edge connector */
+pub type EDGE01 = COL1;
+pub type EDGE02<MODE> = PAD1<MODE>; // <- big pad 1
+pub type EDGE03 = COL2;
+pub type EDGE04 = BTN_A;
+pub type EDGE05 = COL9;
+pub type EDGE06 = COL8;
+pub type EDGE07<MODE> = PAD2<MODE>; // <- big pad 2
+pub type EDGE08<MODE> = p0::P0_18<MODE>;
+pub type EDGE09 = COL7;
+pub type EDGE10 = COL3;
+pub type EDGE11 = BTN_B;
+pub type EDGE12<MODE> = p0::P0_20<MODE>;
+pub type EDGE13<MODE> = PAD3<MODE>; // <- big pad 3
+pub type EDGE14<MODE> = SCK<MODE>;
+pub type EDGE15<MODE> = MISO<MODE>;
+pub type EDGE16<MODE> = MOSI<MODE>;
+pub type EDGE17<MODE> = p0::P0_16<MODE>;
+// EDGE18 -> +V
+// EDGE19 -> +V
+// EDGE20 -> +V
+pub type EDGE21 = SCL;
+pub type EDGE22 = SDA;
+// EDGE23 -> GND
+// EDGE24 -> GND
+// EDGE25 -> GND

--- a/src/led.rs
+++ b/src/led.rs
@@ -1,14 +1,16 @@
 //! On-board user LEDs
 
 use crate::hal::{
-    gpio::{p0, Output, Pin, PushPull},
+    gpio::{Output, Pin, PushPull},
     prelude::*,
 };
+
+use crate::gpio::{COL1, COL2, COL3, COL4, COL5, COL6, COL7, COL8, COL9, ROW1, ROW2, ROW3};
 
 use embedded_hal::blocking::delay::DelayUs;
 
 #[allow(clippy::upper_case_acronyms)]
-type LED = Pin<Output<PushPull>>;
+pub(crate) type LED = Pin<Output<PushPull>>;
 
 const DEFAULT_DELAY_MS: u32 = 2;
 const LED_LAYOUT: [[(usize, usize); 5]; 5] = [
@@ -18,6 +20,21 @@ const LED_LAYOUT: [[(usize, usize); 5]; 5] = [
     [(0, 7), (0, 6), (0, 5), (0, 4), (0, 3)],
     [(2, 2), (1, 6), (2, 0), (1, 5), (2, 1)],
 ];
+
+pub struct Pins {
+    pub col1: COL1,
+    pub col2: COL2,
+    pub col3: COL3,
+    pub col4: COL4,
+    pub col5: COL5,
+    pub col6: COL6,
+    pub col7: COL7,
+    pub col8: COL8,
+    pub col9: COL9,
+    pub row1: ROW1,
+    pub row2: ROW2,
+    pub row3: ROW3,
+}
 
 /// Array of all the LEDs in the 5x5 display on the board
 pub struct Display {
@@ -29,33 +46,24 @@ pub struct Display {
 impl Display {
     /// Initializes all the user LEDs
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        col1: p0::P0_04<Output<PushPull>>,
-        col2: p0::P0_05<Output<PushPull>>,
-        col3: p0::P0_06<Output<PushPull>>,
-        col4: p0::P0_07<Output<PushPull>>,
-        col5: p0::P0_08<Output<PushPull>>,
-        col6: p0::P0_09<Output<PushPull>>,
-        col7: p0::P0_10<Output<PushPull>>,
-        col8: p0::P0_11<Output<PushPull>>,
-        col9: p0::P0_12<Output<PushPull>>,
-        row1: p0::P0_13<Output<PushPull>>,
-        row2: p0::P0_14<Output<PushPull>>,
-        row3: p0::P0_15<Output<PushPull>>,
-    ) -> Self {
+    pub fn new(pins: Pins) -> Self {
         let mut retval = Display {
             delay_ms: DEFAULT_DELAY_MS,
-            rows: [row1.degrade(), row2.degrade(), row3.degrade()],
+            rows: [
+                pins.row1.degrade(),
+                pins.row2.degrade(),
+                pins.row3.degrade(),
+            ],
             cols: [
-                col1.degrade(),
-                col2.degrade(),
-                col3.degrade(),
-                col4.degrade(),
-                col5.degrade(),
-                col6.degrade(),
-                col7.degrade(),
-                col8.degrade(),
-                col9.degrade(),
+                pins.col1.degrade(),
+                pins.col2.degrade(),
+                pins.col3.degrade(),
+                pins.col4.degrade(),
+                pins.col5.degrade(),
+                pins.col6.degrade(),
+                pins.col7.degrade(),
+                pins.col8.degrade(),
+                pins.col9.degrade(),
             ],
         };
         // This is needed to reduce flickering on reset

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub use nrf51_hal as hal;
 pub use nb::*;
 
 pub mod display;
+pub mod gpio;
 pub mod led;
 
 #[macro_export]


### PR DESCRIPTION
This is an attempt to take small steps towards supporting the v2 board by tweaking APIs to make the inclusion easier.

In this step I map pins to the micro:bit names taken from the [v1.5 schematic](https://github.com/bbcmicrobit/hardware/tree/master/V1.5). I'm not sure what all the pins do so I've only included the mode where I'm fairly certain it's correct.

I have also moved the pins out of `led::Display::new` and into a separate struct. I've seen this done in nrf-hal and it seems to make it clearer what each pin is for. I think this will particularly helpful when introducing v2 as the pin layout is quite different.