### PR TITLE
Allow noncontiguous pins in display

### DIFF
--- a/examples/led_blocking.rs
+++ b/examples/led_blocking.rs
@@ -6,10 +6,9 @@ use panic_halt as _;
 
 use cortex_m_rt::entry;
 
-use microbit::hal::{
-    gpio::{p0::Parts as P0Parts, Level},
-    prelude::*,
-    Timer,
+use microbit::{
+    display_pins,
+    hal::{gpio::p0::Parts as P0Parts, prelude::*, Timer},
 };
 
 use microbit::led;
@@ -21,20 +20,7 @@ fn main() -> ! {
         let p0parts = P0Parts::new(p.GPIO);
 
         // Display
-        let pins = led::Pins {
-            row1: p0parts.p0_13.into_push_pull_output(Level::Low),
-            row2: p0parts.p0_14.into_push_pull_output(Level::Low),
-            row3: p0parts.p0_15.into_push_pull_output(Level::Low),
-            col1: p0parts.p0_04.into_push_pull_output(Level::Low),
-            col2: p0parts.p0_05.into_push_pull_output(Level::Low),
-            col3: p0parts.p0_06.into_push_pull_output(Level::Low),
-            col4: p0parts.p0_07.into_push_pull_output(Level::Low),
-            col5: p0parts.p0_08.into_push_pull_output(Level::Low),
-            col6: p0parts.p0_09.into_push_pull_output(Level::Low),
-            col7: p0parts.p0_10.into_push_pull_output(Level::Low),
-            col8: p0parts.p0_11.into_push_pull_output(Level::Low),
-            col9: p0parts.p0_12.into_push_pull_output(Level::Low),
-        };
+        let pins = display_pins!(p0parts);
         let mut leds = led::Display::new(pins);
 
         #[allow(non_snake_case)]

--- a/src/display/control.rs
+++ b/src/display/control.rs
@@ -7,19 +7,23 @@
 use crate::pac;
 use tiny_led_matrix::DisplayControl;
 
-const fn bit_range(lo: usize, count: usize) -> u32 {
-    ((1 << count) - 1) << lo
+const fn pin_bits(pins: &[usize]) -> u32 {
+    let mut i: usize = 0;
+    let mut bits: u32 = 0;
+    while i < pins.len() {
+        bits |= 1 << pins[i];
+        i += 1;
+    }
+    bits
 }
 
 pub(crate) const MATRIX_COLS: usize = 9;
-const FIRST_COL_PIN: usize = 4;
-const LAST_COL_PIN: usize = FIRST_COL_PIN + MATRIX_COLS - 1;
-const COL_BITS: u32 = bit_range(FIRST_COL_PIN, MATRIX_COLS);
+const COLS: [usize; MATRIX_COLS] = [4, 5, 6, 7, 8, 9, 10, 11, 12];
+const COL_BITS: u32 = pin_bits(&COLS);
 
 pub(crate) const MATRIX_ROWS: usize = 3;
-const FIRST_ROW_PIN: usize = 13;
-const LAST_ROW_PIN: usize = FIRST_ROW_PIN + MATRIX_ROWS - 1;
-const ROW_BITS: u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
+const ROWS: [usize; MATRIX_ROWS] = [13, 14, 15];
+const ROW_BITS: u32 = pin_bits(&ROWS);
 
 /// Wrapper for `nrf51::GPIO` for passing to the display code.
 ///
@@ -28,9 +32,14 @@ const ROW_BITS: u32 = bit_range(FIRST_ROW_PIN, MATRIX_ROWS);
 /// [`DisplayControl`]: tiny_led_matrix::DisplayControl
 pub(crate) struct MicrobitGpio<'a>(pub &'a pac::GPIO);
 
-/// Returns the GPIO pin numbers corresponding to the columns in a ColumnSet.
-fn column_pins(cols: u32) -> u32 {
-    cols << FIRST_COL_PIN
+/// Returns the GPIO pin numbers corresponding to the columns in a Columnt et.
+fn column_pins(mut cols: u32) -> u32 {
+    let mut result = 0u32;
+    for pin in COLS.iter() {
+        result |= (cols & 1) << pin;
+        cols >>= 1;
+    }
+    result
 }
 
 /// Implementation of [`DisplayControl`] for the micro:bit's GPIO peripheral.
@@ -44,23 +53,24 @@ fn column_pins(cols: u32) -> u32 {
 impl DisplayControl for MicrobitGpio<'_> {
     fn initialise_for_display(&mut self) {
         let gpio = &self.0;
-        for ii in FIRST_COL_PIN..=LAST_COL_PIN {
-            gpio.pin_cnf[ii].write(|w| w.dir().output());
+        for ii in COLS.iter() {
+            gpio.pin_cnf[*ii].write(|w| w.dir().output());
         }
-        for ii in FIRST_ROW_PIN..=LAST_ROW_PIN {
-            gpio.pin_cnf[ii].write(|w| w.dir().output());
+        for ii in ROWS.iter() {
+            gpio.pin_cnf[*ii].write(|w| w.dir().output());
         }
 
         // Set all cols high.
         gpio.outset
-            .write(|w| unsafe { w.bits((FIRST_COL_PIN..=LAST_COL_PIN).map(|pin| 1 << pin).sum()) });
+            .write(|w| unsafe { w.bits(COLS.iter().map(|pin| 1 << pin).sum()) });
     }
 
     fn display_row_leds(&mut self, row: usize, cols: u32) {
         let gpio = &self.0;
         // To light an LED, we set the row bit and clear the col bit.
-        let rows_to_set = 1 << (FIRST_ROW_PIN + row);
+        let rows_to_set = 1 << ROWS[row];
         let rows_to_clear = ROW_BITS ^ rows_to_set;
+
         let cols_to_clear = column_pins(cols);
         let cols_to_set = COL_BITS ^ cols_to_clear;
 

--- a/src/display/image.rs
+++ b/src/display/image.rs
@@ -29,6 +29,7 @@ impl GreyscaleImage {
         GreyscaleImage(*data)
     }
 
+    /// Construct a GreyscaleImage with all LEDs turned off.
     pub const fn blank() -> GreyscaleImage {
         GreyscaleImage([[0; 5]; 5])
     }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -134,7 +134,7 @@ pub mod image;
 pub use matrix::MicrobitFrame;
 pub use timer::MicrobitDisplayTimer;
 
-use crate::hal::timer::Instance;
+use crate::{gpio::DisplayPins, hal::timer::Instance};
 
 use control::MicrobitGpio;
 
@@ -151,9 +151,9 @@ use control::MicrobitGpio;
 /// ```
 pub fn initialise_display<T: Instance>(
     timer: &mut MicrobitDisplayTimer<T>,
-    gpio: &mut crate::pac::GPIO,
+    _pins: &mut DisplayPins,
 ) {
-    tiny_led_matrix::initialise_control(&mut MicrobitGpio(gpio));
+    tiny_led_matrix::initialise_control(&mut MicrobitGpio {});
     tiny_led_matrix::initialise_timer(timer);
 }
 
@@ -186,7 +186,7 @@ pub fn initialise_display<T: Instance>(
 pub fn handle_display_event<T: Instance>(
     display: &mut Display<MicrobitFrame>,
     timer: &mut MicrobitDisplayTimer<T>,
-    gpio: &mut crate::pac::GPIO,
+    _pins: &mut DisplayPins,
 ) {
-    display.handle_event(timer, &mut MicrobitGpio(gpio));
+    display.handle_event(timer, &mut MicrobitGpio {});
 }

--- a/src/display/mod.rs
+++ b/src/display/mod.rs
@@ -47,8 +47,8 @@
 //! The [`Render`] trait defines the interface that an image-like type needs
 //! to provide in order to be displayed.
 //!
-//! It contains a single function: [`brightness_at(x,
-//! y)`][display::Render::brightness_at], returning a brightness level.
+//! It contains a single function: [`brightness_at(x, y)`](Render::brightness_at),
+//! returning a brightness level.
 //!
 //! The [`image`] submodule provides two static image types implementing
 //! `Render`:
@@ -77,7 +77,7 @@
 //!
 //! # Timer integration
 //!
-//! The `Display` expects to control a single timer. It can use the
+//! The [`Display`] expects to control a single timer. It can use the
 //! micro:bit's `TIMER0`, `TIMER1`, or `TIMER2`.
 //!
 //! This uses a 6ms period to light each of the three internal LED rows, so
@@ -100,14 +100,14 @@
 //! When your program starts:
 //! * create a [`MicrobitDisplayTimer`] struct, passing the timer you chose to
 //! [`MicrobitDisplayTimer::new()`]
-//! * call [`initialise_display()`], passing it the `MicrobitDisplayTimer` and
-//! the gpio peripheral
+//! * call [`initialise_display()`], passing it the `MicrobitDisplayTimer` and the
+//! [`crate::led::Pins`]
 //! * create a [`Display`] struct (a `Display<MicrobitFrame>`).
 //!
 //! In an interrupt handler for the timer, call [`handle_display_event()`].
 //!
 //! To change what's displayed: create a [`MicrobitFrame`] instance, use
-//! [`.set()`](`display::Frame::set()`) to put an image (something implementing
+//! [`.set()`](`Frame::set()`) to put an image (something implementing
 //! [`Render`]) in it, then call [`Display::set_frame()`]. Note you'll have to
 //! `use microbit::display::Frame` to make `set()` available.
 //!
@@ -121,22 +121,6 @@
 //!
 //! [dal]: https://lancaster-university.github.io/microbit-docs/
 //! [micropython]: https://microbit-micropython.readthedocs.io/
-//!
-//! [`BitImage`]: display::image::BitImage
-//! [`Display`]: display::Display
-//! [`Display::set_frame()`]: display::Display::set_frame
-//! [`Frame`]: display::Frame
-//! [`Matrix`]: display::Matrix
-//! [`MicrobitFrame`]: display::MicrobitFrame
-//! [`MicrobitDisplayTimer`]: display::MicrobitDisplayTimer
-//! [`MicrobitDisplayTimer::new()`]: display::MicrobitDisplayTimer::new
-//! [`Render`]: display::Render
-//! [`image`]: display::image
-//! [`handle_display_event()`]: display::handle_display_event
-//! [`initialise_display()`]: display::initialise_display
-//! [`DisplayTimer`]: tiny_led_matrix::DisplayTimer
-//! [`GreyscaleImage`]: display::image::GreyscaleImage
-//!
 
 #[doc(no_inline)]
 pub use tiny_led_matrix::{Display, Frame, Render, MAX_BRIGHTNESS};

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -4,7 +4,7 @@
 //! [v1.5 schematic](https://github.com/bbcmicrobit/hardware/tree/master/V1.5).
 //! Where appropriate the pins are restricted with the appropriate `MODE`
 //! from `nrf-hal`.
-#![allow(clippy::upper_case_acronyms)]
+#![allow(clippy::upper_case_acronyms, missing_docs)]
 use crate::hal::gpio::{p0, Floating, Input, Output, PushPull};
 
 /* GPIO pads */
@@ -27,6 +27,7 @@ pub type ROW1 = p0::P0_13<Output<PushPull>>;
 pub type ROW2 = p0::P0_14<Output<PushPull>>;
 pub type ROW3 = p0::P0_15<Output<PushPull>>;
 
+/// GPIO pins connected to the LED matrix
 pub struct DisplayPins {
     pub col1: COL1,
     pub col2: COL2,
@@ -42,6 +43,7 @@ pub struct DisplayPins {
     pub row3: ROW3,
 }
 
+/// Create [DisplayPins] from a [GPIO Parts](crate::hal::gpio::p0::Parts)
 #[macro_export]
 macro_rules! display_pins {
     ( $p0parts:expr ) => {{

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -27,6 +27,43 @@ pub type ROW1 = p0::P0_13<Output<PushPull>>;
 pub type ROW2 = p0::P0_14<Output<PushPull>>;
 pub type ROW3 = p0::P0_15<Output<PushPull>>;
 
+pub struct DisplayPins {
+    pub col1: COL1,
+    pub col2: COL2,
+    pub col3: COL3,
+    pub col4: COL4,
+    pub col5: COL5,
+    pub col6: COL6,
+    pub col7: COL7,
+    pub col8: COL8,
+    pub col9: COL9,
+    pub row1: ROW1,
+    pub row2: ROW2,
+    pub row3: ROW3,
+}
+
+#[macro_export]
+macro_rules! display_pins {
+    ( $p0parts:expr ) => {{
+        use microbit::{gpio::DisplayPins, hal::gpio::Level};
+
+        DisplayPins {
+            row1: $p0parts.p0_13.into_push_pull_output(Level::Low),
+            row2: $p0parts.p0_14.into_push_pull_output(Level::Low),
+            row3: $p0parts.p0_15.into_push_pull_output(Level::Low),
+            col1: $p0parts.p0_04.into_push_pull_output(Level::Low),
+            col2: $p0parts.p0_05.into_push_pull_output(Level::Low),
+            col3: $p0parts.p0_06.into_push_pull_output(Level::Low),
+            col4: $p0parts.p0_07.into_push_pull_output(Level::Low),
+            col5: $p0parts.p0_08.into_push_pull_output(Level::Low),
+            col6: $p0parts.p0_09.into_push_pull_output(Level::Low),
+            col7: $p0parts.p0_10.into_push_pull_output(Level::Low),
+            col8: $p0parts.p0_11.into_push_pull_output(Level::Low),
+            col9: $p0parts.p0_12.into_push_pull_output(Level::Low),
+        }
+    }};
+}
+
 /* buttons */
 pub type BTN_A = p0::P0_17<Input<Floating>>;
 pub type BTN_B = p0::P0_26<Input<Floating>>;

--- a/src/led.rs
+++ b/src/led.rs
@@ -5,7 +5,7 @@ use crate::hal::{
     prelude::*,
 };
 
-use crate::gpio::{COL1, COL2, COL3, COL4, COL5, COL6, COL7, COL8, COL9, ROW1, ROW2, ROW3};
+use crate::gpio::DisplayPins;
 
 use embedded_hal::blocking::delay::DelayUs;
 
@@ -21,21 +21,6 @@ const LED_LAYOUT: [[(usize, usize); 5]; 5] = [
     [(2, 2), (1, 6), (2, 0), (1, 5), (2, 1)],
 ];
 
-pub struct Pins {
-    pub col1: COL1,
-    pub col2: COL2,
-    pub col3: COL3,
-    pub col4: COL4,
-    pub col5: COL5,
-    pub col6: COL6,
-    pub col7: COL7,
-    pub col8: COL8,
-    pub col9: COL9,
-    pub row1: ROW1,
-    pub row2: ROW2,
-    pub row3: ROW3,
-}
-
 /// Array of all the LEDs in the 5x5 display on the board
 pub struct Display {
     delay_ms: u32,
@@ -46,7 +31,7 @@ pub struct Display {
 impl Display {
     /// Initializes all the user LEDs
     #[allow(clippy::too_many_arguments)]
-    pub fn new(pins: Pins) -> Self {
+    pub fn new(pins: DisplayPins) -> Self {
         let mut retval = Display {
             delay_ms: DEFAULT_DELAY_MS,
             rows: [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
+//! microbit contains everything required to get started with the use of Rust
+//! to create firmwares for the fabulous [BBC micro:bit](https://microbit.org)
+//! microcontroller board.
 #![no_std]
+#![deny(missing_docs)]
 #![allow(non_camel_case_types)]
 
 pub use hal::pac;
@@ -11,6 +15,7 @@ pub mod display;
 pub mod gpio;
 pub mod led;
 
+/// Create a [Uart](hal::uart::Uart] client with the default pins
 #[macro_export]
 macro_rules! serial_port {
     ( $gpio:expr, $uart:expr, $speed:expr ) => {{


### PR DESCRIPTION
In the micro:bit v2 the LED matrix pins are not placed next to each other. This change updates `display::control` so that it is configured with arrays of pin IDs rather than start and end IDs.

I would ideally like to change the interface of the `display` module so that it doesn't take a mutable reference to the `pac::Periferals::GPIO` instance. As far as I can tell taking a mutable reference to `GPIO` means that the hal can't be used for the other pins as `hal::gpio::p0::Parts` requires ownership of `GPIO`. I think it's done like this for performance reasons so that multiple pins can be set high or low at once but it seems like a very high price to pay.

If we could change the interface to be around `hal::gpio::Pin` instances we could reuse the `Pins` struct from #33

I am not confident in my assessment here though and have some questions:
- Am I correct in asserting that using `GPIO` like this makes using `hal::gpio::p0::Parts` impossible?
- Am I correct in asserting that this is done for performance?
- Is interacting with the Pins individually really that slow?