### PR TITLE
Add GitHub workflow to sync main with master

### DIFF
--- a/.github/workflows/sync_master.yaml
+++ b/.github/workflows/sync_master.yaml
@@ -1,0 +1,19 @@
+name: Sync main with master
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        fetch-depth: 0
+        ssh-key: ${{ SECRET_DEPLOY_KEY }}
+
+      - run: |
+        git checkout master
+        git merge --ff-only main
+        git push origin HEAD


### PR DESCRIPTION
If the main line branch is renamed to `main` then it would be useful to
keep `master` in sync to avoid any compatibility issues.

This requires a Deploy Key for writing to the repo

https://docs.github.com/en/developers/overview/managing-deploy-keys#deploy-keys
