### PR TITLE
Bump version to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2021-04-29
+
 ### Added
 
 - Add `microbit::gpio` module with pins mapped to micro:bit names
@@ -19,4 +21,5 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix rustdoc warnings
 - Upgrade nrf51-hal to 0.12.1
 
-[Unreleased]: https://github.com/therealprof/microbit/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/therealprof/microbit/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/therealprof/microbit/compare/v0.8.0...v0.9.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license = "0BSD"
 name = "microbit"
 readme = "README.md"
 repository = "https://github.com/therealprof/microbit"
-version = "0.8.0"
+version = "0.9.0"
 
 [dependencies]
 cortex-m = "0.6.1"


### PR DESCRIPTION
See #35

### Added

- Add `microbit::gpio` module with pins mapped to micro:bit names
- Refactor `microbit::display` and `microbit::led` to accept `gpio::Pins`
- Make probe-run the default runner
- Rewrite `serial_port` as a macro

### Fixed

- Fix rustdoc warnings
- Upgrade nrf51-hal to 0.12.1