### PR TITLE
blocking display sample: add comment with missing duration unit

### DIFF
--- a/microbit-common/src/display/blocking.rs
+++ b/microbit-common/src/display/blocking.rs
@@ -29,13 +29,14 @@
 //!     [0, 0, 1, 0, 0],
 //! ];
 //! loop {
+//!     // block this loop and show the image for 1000 milliseconds
 //!     display.show(&mut timer, heart, 1000);
 //!     display.clear();
 //!     timer.delay_ms(250);
 //! }
 //! ```
 //!
-//! The coordiante system is oriented so the 'bottom' (x,4) row is the edge with the edge
+//! The coordinate system is oriented so the 'bottom' (x,4) row is the edge with the edge
 //! connector. That means that
 //!
 //! ```no_run


### PR DESCRIPTION
I believe there was absolutely nothing said about the `duration` parameter. While many readers could probably guess its purpose, guessing its unit (ms) was more of a challenge. Guessing is not fun in any case.