### PR TITLE
nonblocking display: fix broken github.com URLs to examples

### DIFF
--- a/microbit-common/src/display/nonblocking/mod.rs
+++ b/microbit-common/src/display/nonblocking/mod.rs
@@ -148,8 +148,8 @@
 //! You can call `show()` at any time, so long as you're not interrupting, or interruptable by,
 //! [`Display::handle_display_event()`].
 //!
-//! See [`display_rtic`](https://github.com/nrf-rs/microbit/blob/master/examples/display_rtic) or
-//! [`display_nonblocking`](https://github.com/nrf-rs/microbit/blob/master/examples/display_nonblocking)
+//! See [`display_rtic`](https://github.com/nrf-rs/microbit/blob/main/examples/display-rtic) or
+//! [`display_nonblocking`](https://github.com/nrf-rs/microbit/blob/main/examples/display-nonblocking)
 //! example for a complete working example.
 //!
 //! [dal]: https://lancaster-university.github.io/microbit-docs/


### PR DESCRIPTION
GitHub has a feature to rename branches and get redirections for free but it looks like it was not used in this case?

After a quick look at the git log, I don't know how the underscores ever work. ..So maybe there never was any master branch either after all, who knows.

Anyway the new links work now!